### PR TITLE
Use custom hazy UTC time struct to unmarshal date times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ unit-test:
 	go test -race ./... -tags=unitTest
 
 run-int-test:
-	PUBSUB_EMULATOR_HOST=localhost:8539 go test *.go
+	PUBSUB_EMULATOR_HOST=localhost:8539 go test github.com/ONSdigital/census-rm-pubsub-adapter
 
 int-test: down up-dependencies run-int-test down
 

--- a/main.go
+++ b/main.go
@@ -23,25 +23,7 @@ func main() {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
 
-	// Start EQ receipt processing
-	eqReceiptProcessor := processor.NewEqReceiptProcessor(ctx, appConfig)
-	go eqReceiptProcessor.Consume(ctx)
-	go eqReceiptProcessor.Process(ctx)
-
-	// Start offline receipt processing
-	offlineReceiptProcessor := processor.NewOfflineReceiptProcessor(ctx, appConfig)
-	go offlineReceiptProcessor.Consume(ctx)
-	go offlineReceiptProcessor.Process(ctx)
-
-	// Start PPO undelivered processing
-	ppoUndeliveredProcessor := processor.NewPpoUndeliveredProcessor(ctx, appConfig)
-	go ppoUndeliveredProcessor.Consume(ctx)
-	go ppoUndeliveredProcessor.Process(ctx)
-
-	// Start QM undelivered processing
-	qmUndeliveredProcessor := processor.NewQmUndeliveredProcessor(ctx, appConfig)
-	go qmUndeliveredProcessor.Consume(ctx)
-	go qmUndeliveredProcessor.Process(ctx)
+	processors := StartProcessors(ctx, appConfig)
 
 	// block until we receive eqReceiptProcessor shutdown signal
 	select {
@@ -62,10 +44,9 @@ func main() {
 		defer shutdownCancel()
 
 		log.Printf("Rabbit Cleanup")
-		eqReceiptProcessor.CloseRabbit()
-		offlineReceiptProcessor.CloseRabbit()
-		ppoUndeliveredProcessor.CloseRabbit()
-		qmUndeliveredProcessor.CloseRabbit()
+		for _, p := range processors {
+			p.CloseRabbit()
+		}
 
 	}()
 
@@ -75,4 +56,33 @@ func main() {
 	log.Printf("CloseRabbit complete")
 	os.Exit(1)
 
+}
+
+func StartProcessors(ctx context.Context, cfg *config.Configuration) []*processor.Processor {
+	processors := make([]*processor.Processor, 0)
+
+	// Start EQ receipt processing
+	eqReceiptProcessor := processor.NewEqReceiptProcessor(ctx, cfg)
+	go eqReceiptProcessor.Consume(ctx)
+	go eqReceiptProcessor.Process(ctx)
+	processors = append(processors, eqReceiptProcessor.Processor)
+
+	// Start offline receipt processing
+	offlineReceiptProcessor := processor.NewOfflineReceiptProcessor(ctx, cfg)
+	go offlineReceiptProcessor.Consume(ctx)
+	go offlineReceiptProcessor.Process(ctx)
+	processors = append(processors, offlineReceiptProcessor.Processor)
+
+	// Start PPO undelivered processing
+	ppoUndeliveredProcessor := processor.NewPpoUndeliveredProcessor(ctx, cfg)
+	go ppoUndeliveredProcessor.Consume(ctx)
+	go ppoUndeliveredProcessor.Process(ctx)
+	processors = append(processors, ppoUndeliveredProcessor.Processor)
+
+	// Start QM undelivered processing
+	qmUndeliveredProcessor := processor.NewQmUndeliveredProcessor(ctx, cfg)
+	go qmUndeliveredProcessor.Consume(ctx)
+	go qmUndeliveredProcessor.Process(ctx)
+	processors = append(processors, qmUndeliveredProcessor.Processor)
+	return processors
 }

--- a/main.go
+++ b/main.go
@@ -65,24 +65,24 @@ func StartProcessors(ctx context.Context, cfg *config.Configuration) []*processo
 	eqReceiptProcessor := processor.NewEqReceiptProcessor(ctx, cfg)
 	go eqReceiptProcessor.Consume(ctx)
 	go eqReceiptProcessor.Process(ctx)
-	processors = append(processors, eqReceiptProcessor.Processor)
+	processors = append(processors, eqReceiptProcessor)
 
 	// Start offline receipt processing
 	offlineReceiptProcessor := processor.NewOfflineReceiptProcessor(ctx, cfg)
 	go offlineReceiptProcessor.Consume(ctx)
 	go offlineReceiptProcessor.Process(ctx)
-	processors = append(processors, offlineReceiptProcessor.Processor)
+	processors = append(processors, offlineReceiptProcessor)
 
 	// Start PPO undelivered processing
 	ppoUndeliveredProcessor := processor.NewPpoUndeliveredProcessor(ctx, cfg)
 	go ppoUndeliveredProcessor.Consume(ctx)
 	go ppoUndeliveredProcessor.Process(ctx)
-	processors = append(processors, ppoUndeliveredProcessor.Processor)
+	processors = append(processors, ppoUndeliveredProcessor)
 
 	// Start QM undelivered processing
 	qmUndeliveredProcessor := processor.NewQmUndeliveredProcessor(ctx, cfg)
 	go qmUndeliveredProcessor.Consume(ctx)
 	go qmUndeliveredProcessor.Process(ctx)
-	processors = append(processors, qmUndeliveredProcessor.Processor)
+	processors = append(processors, qmUndeliveredProcessor)
 	return processors
 }

--- a/models/hazyUtcTime.go
+++ b/models/hazyUtcTime.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"strings"
+	"time"
+)
+
+type HazyUtcTime struct {
+	// For use in JSON models where the time may or may not include the timezone
+	time.Time
+}
+
+func (t *HazyUtcTime) UnmarshalJSON(buf []byte) error {
+	timeString := strings.Trim(string(buf), `"`)
+	parsedTime, err := time.Parse("2006-01-02T15:04:05Z07:00", timeString)
+	if err != nil {
+		parsedTime, err = time.Parse("2006-01-02T15:04:05", timeString)
+		if err != nil {
+			return err
+		}
+	}
+	t.Time = parsedTime
+	return nil
+}

--- a/models/hazyUtcTime_test.go
+++ b/models/hazyUtcTime_test.go
@@ -32,7 +32,7 @@ func testUnmarshalJSON(timeBuf []byte, expectedTime *time.Time) func(t *testing.
 		_, actualTzOffset := hazyUtcTime.Zone()
 		_, expectedTzOffset := expectedTime.Zone()
 		if actualTzOffset != expectedTzOffset {
-			t.Errorf("Expected UTC TZ, got: %d", actualTzOffset)
+			t.Errorf("Expected TZ offset: %d, got: %d", expectedTzOffset, actualTzOffset)
 		}
 	}
 }

--- a/models/hazyUtcTime_test.go
+++ b/models/hazyUtcTime_test.go
@@ -8,10 +8,12 @@ import (
 
 func TestUnmarshalJSON(t *testing.T) {
 	expectedTimeUtc, _ := time.Parse("2006-01-02T15:04:05Z07:00", "2008-08-24T00:00:00Z")
+	expectedTimeBst, _ := time.Parse("2006-01-02T15:04:05Z07:00", "2008-08-24T00:00:00+01:00")
 
 	t.Run("Without TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00"`), &expectedTimeUtc))
 	t.Run("With zulu TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00Z"`), &expectedTimeUtc))
-	t.Run("With explicit TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00+00:00"`), &expectedTimeUtc))
+	t.Run("With explicit UTC TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00+00:00"`), &expectedTimeUtc))
+	t.Run("With explicit non zero TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00+01:00"`), &expectedTimeBst))
 }
 
 func testUnmarshalJSON(timeBuf []byte, expectedTime *time.Time) func(t *testing.T) {
@@ -27,9 +29,10 @@ func testUnmarshalJSON(timeBuf []byte, expectedTime *time.Time) func(t *testing.
 			t.Errorf("Expected time: %s, got: %s", expectedTime, hazyUtcTime)
 		}
 
-		actualTz, _ := hazyUtcTime.Zone()
-		if reflect.DeepEqual(0, actualTz) {
-			t.Errorf("Expected UTC TZ, got: %s", actualTz)
+		_, actualTzOffset := hazyUtcTime.Zone()
+		_, expectedTzOffset := expectedTime.Zone()
+		if actualTzOffset != expectedTzOffset {
+			t.Errorf("Expected UTC TZ, got: %d", actualTzOffset)
 		}
 	}
 }

--- a/models/hazyUtcTime_test.go
+++ b/models/hazyUtcTime_test.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	expectedTimeUtc, _ := time.Parse("2006-01-02T15:04:05Z07:00", "2008-08-24T00:00:00Z")
+
+	t.Run("Without TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00"`), &expectedTimeUtc))
+	t.Run("With zulu TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00Z"`), &expectedTimeUtc))
+	t.Run("With explicit TZ", testUnmarshalJSON([]byte(`"2008-08-24T00:00:00+00:00"`), &expectedTimeUtc))
+}
+
+func testUnmarshalJSON(timeBuf []byte, expectedTime *time.Time) func(t *testing.T) {
+	return func(t *testing.T) {
+
+		hazyUtcTime := HazyUtcTime{}
+		if err := hazyUtcTime.UnmarshalJSON(timeBuf); err != nil {
+			t.Error(err)
+			return
+		}
+
+		if reflect.DeepEqual(expectedTime, hazyUtcTime) {
+			t.Errorf("Expected time: %s, got: %s", expectedTime, hazyUtcTime)
+		}
+
+		actualTz, _ := hazyUtcTime.Zone()
+		if reflect.DeepEqual(0, actualTz) {
+			t.Errorf("Expected UTC TZ, got: %s", actualTz)
+		}
+	}
+}

--- a/models/offlineReceipt.go
+++ b/models/offlineReceipt.go
@@ -1,13 +1,11 @@
 package models
 
-import "time"
-
 type OfflineReceipt struct {
-	TimeCreated     time.Time `json:"dateTime"`
-	TransactionId   string    `json:"transactionId"`
-	QuestionnaireId string    `json:"questionnaireId"`
-	Unreceipt       bool      `json:"unreceipt"`
-	Channel         string    `json:"channel"`
+	TimeCreated     HazyUtcTime `json:"dateTime"`
+	TransactionId   string      `json:"transactionId"`
+	QuestionnaireId string      `json:"questionnaireId"`
+	Unreceipt       bool        `json:"unreceipt"`
+	Channel         string      `json:"channel"`
 }
 
 func (o OfflineReceipt) GetTransactionId() string {

--- a/models/ppoUndelivered.go
+++ b/models/ppoUndelivered.go
@@ -1,12 +1,10 @@
 package models
 
-import "time"
-
 type PpoUndelivered struct {
-	TransactionId string    `json:"transactionId"`
-	DateTime      time.Time `json:"dateTime"`
-	CaseRef       string    `json:"caseRef"`
-	ProductCode   string    `json:"productCode"`
+	TransactionId string      `json:"transactionId"`
+	DateTime      HazyUtcTime `json:"dateTime"`
+	CaseRef       string      `json:"caseRef"`
+	ProductCode   string      `json:"productCode"`
 }
 
 func (p PpoUndelivered) GetTransactionId() string {

--- a/models/qmUndelivered.go
+++ b/models/qmUndelivered.go
@@ -1,11 +1,9 @@
 package models
 
-import "time"
-
 type QmUndelivered struct {
-	TransactionId   string    `json:"transactionId"`
-	DateTime        time.Time `json:"dateTime"`
-	QuestionnaireId string    `json:"questionnaireId"`
+	TransactionId   string      `json:"transactionId"`
+	DateTime        HazyUtcTime `json:"dateTime"`
+	QuestionnaireId string      `json:"questionnaireId"`
 }
 
 func (q QmUndelivered) GetTransactionId() string {

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -9,14 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-type EqReceiptProcessor struct {
-	*Processor
-}
 
-func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *EqReceiptProcessor {
-	eqReceiptProcessor := &EqReceiptProcessor{}
-	eqReceiptProcessor.Processor = NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt)
-	return eqReceiptProcessor
+func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+	return NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt)
 }
 
 func unmarshalEqReceipt(data []byte) (models.PubSubMessage, error) {

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-
 func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
 	return NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt)
 }

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -9,14 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-type OfflineReceiptProcessor struct {
-	*Processor
-}
-
-func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *OfflineReceiptProcessor {
-	offlineReceiptProcessor := &OfflineReceiptProcessor{}
-	offlineReceiptProcessor.Processor = NewProcessor(ctx, appConfig, appConfig.OfflineReceiptProject, appConfig.OfflineReceiptSubscription, appConfig.ReceiptRoutingKey, convertOfflineReceiptToRmMessage, unmarshalOfflineReceipt)
-	return offlineReceiptProcessor
+func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+	return NewProcessor(ctx, appConfig, appConfig.OfflineReceiptProject, appConfig.OfflineReceiptSubscription, appConfig.ReceiptRoutingKey, convertOfflineReceiptToRmMessage, unmarshalOfflineReceipt)
 }
 
 func unmarshalOfflineReceipt(data []byte) (models.PubSubMessage, error) {

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -38,7 +38,7 @@ func convertOfflineReceiptToRmMessage(receipt models.PubSubMessage) (*models.RmM
 			Type:          "RESPONSE_RECEIVED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       offlineReceipt.Channel,
-			DateTime:      offlineReceipt.TimeCreated,
+			DateTime:      offlineReceipt.TimeCreated.Time,
 			TransactionID: offlineReceipt.TransactionId,
 		},
 		Payload: models.RmPayload{

--- a/processor/offlineReceiptProcessor_test.go
+++ b/processor/offlineReceiptProcessor_test.go
@@ -9,8 +9,9 @@ import (
 
 func TestConvertOfflineReceiptToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
+	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
 	offlineReceiptMessage := models.OfflineReceipt{
-		TimeCreated:     timeCreated,
+		TimeCreated:     hazyTimeCreated,
 		TransactionId:   "abc123xxx",
 		QuestionnaireId: "01213213213",
 		Unreceipt:       false,

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-
 func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
 	return NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered)
 }

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -21,8 +21,7 @@ func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configura
 
 func unmarshalPpoUndelivered(data []byte) (models.PubSubMessage, error) {
 	var ppoUndelivered models.PpoUndelivered
-	err := json.Unmarshal(data, &ppoUndelivered)
-	if err != nil {
+	if err := json.Unmarshal(data, &ppoUndelivered); err != nil {
 		return nil, err
 	}
 	return ppoUndelivered, nil
@@ -39,7 +38,7 @@ func convertPpoUndeliveredToRmMessage(message models.PubSubMessage) (*models.RmM
 			Type:          "UNDELIVERED_MAIL_REPORTED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "PPO",
-			DateTime:      ppoUndelivered.DateTime,
+			DateTime:      ppoUndelivered.DateTime.Time,
 			TransactionID: ppoUndelivered.TransactionId,
 		},
 		Payload: models.RmPayload{

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -9,14 +9,9 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-type ppoUndeliveredProcessor struct {
-	*Processor
-}
 
-func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *ppoUndeliveredProcessor {
-	ppoUndeliveredProcessor := &ppoUndeliveredProcessor{}
-	ppoUndeliveredProcessor.Processor = NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered)
-	return ppoUndeliveredProcessor
+func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+	return NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered)
 }
 
 func unmarshalPpoUndelivered(data []byte) (models.PubSubMessage, error) {

--- a/processor/ppoUndeliveredProcessor_test.go
+++ b/processor/ppoUndeliveredProcessor_test.go
@@ -9,8 +9,9 @@ import (
 
 func TestConvertPpoUndeliveredToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
+	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
 	ppoUndeliveredMessage := models.PpoUndelivered{
-		DateTime:      timeCreated,
+		DateTime:      hazyTimeCreated,
 		TransactionId: "abc123xxx",
 		CaseRef:       "123456789",
 		ProductCode:   "P_TEST_1",

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -39,7 +39,7 @@ func convertQmUndeliveredToRmMessage(message models.PubSubMessage) (*models.RmMe
 			Type:          "UNDELIVERED_MAIL_REPORTED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "QM",
-			DateTime:      qmUndelivered.DateTime,
+			DateTime:      qmUndelivered.DateTime.Time,
 			TransactionID: qmUndelivered.TransactionId,
 		},
 		Payload: models.RmPayload{

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -9,14 +9,8 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-type qmUndeliveredProcessor struct {
-	*Processor
-}
-
-func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *qmUndeliveredProcessor {
-	qmUndeliveredProcessor := &qmUndeliveredProcessor{}
-	qmUndeliveredProcessor.Processor = NewProcessor(ctx, appConfig, appConfig.QmUndeliveredProject, appConfig.QmUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertQmUndeliveredToRmMessage, unmarshalQmUndelivered)
-	return qmUndeliveredProcessor
+func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+	return NewProcessor(ctx, appConfig, appConfig.QmUndeliveredProject, appConfig.QmUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertQmUndeliveredToRmMessage, unmarshalQmUndelivered)
 }
 
 func unmarshalQmUndelivered(data []byte) (models.PubSubMessage, error) {

--- a/processor/qmUndeliveredProcessor_test.go
+++ b/processor/qmUndeliveredProcessor_test.go
@@ -9,8 +9,9 @@ import (
 
 func TestConvertQmUndeliveredToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
+	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
 	qmUndeliveredMessage := models.QmUndelivered{
-		DateTime:        timeCreated,
+		DateTime:        hazyTimeCreated,
 		TransactionId:   "abc123xxx",
 		QuestionnaireId: "01213213213",
 	}


### PR DESCRIPTION
# Motivation and Context
The date times we get on offline receipts and undelivered mail may or may not have a `Z` indicating UTC ('zulu') time. The pubsub adapter needs to handle this and assume the times are UTC if they do not include the character.

# What has changed
* Refactor removing unecessary extra processor structs
* Create struct for unmarshalling 'hazy' UTC times
* Use new relaxed time struct for offline and undelivered mail pubsub message models
* Factor the starting of the processors into a method and use that in the tests

# How to test?
Run the acceptance tests using this pubsub adapter instead of the existing python service
1. Checkout master of census-rm-docker-dev and run `make pull up` to start up RM locally
1. Run `docker stop pubsub` to stop the python pubsub service
1. Copy the docker dev config out of the README into the environment you're running the service in (e.g. the run config in golang)
1. Run the pubsub adapter main method to start it up configured to run against docker dev
1. Run the acceptance tests

# Links
https://trello.com/c/8yopuBcd/896-pubsub-adapter-handle-date-formats-5
<!--- Add any links to issues (Jira, Trello, GitHub Issues) -->
<!--- Links to any documentation. -->
<!--- Links to any related PRs. -->
