### PR TITLE
Readiness probe and graceful shutdown on consumer failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ fabric.properties
 # vendor/
 
 census-rm-pubsub-adapter
+*tmpTest*

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,8 @@ import (
 )
 
 type Configuration struct {
+	ReadinessFilePath string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
+
 	// Rabbit
 	RabbitHost             string `envconfig:"RABBIT_HOST" required:"true"`
 	RabbitPort             string `envconfig:"RABBIT_PORT" required:"true"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,9 @@ services:
       - QM_UNDELIVERED_SUBSCRIPTION_PROJECT=qm-undelivered-project
       - PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
     restart: on-failure
+    healthcheck:
+      test: ["CMD", "find", "/tmp/pubsub-adapter-ready", "-mmin", "-1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 1s

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/ONSdigital/census-rm-pubsub-adapter/config"
 	"github.com/ONSdigital/census-rm-pubsub-adapter/processor"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/readiness"
 	"github.com/pkg/errors"
 	"log"
 	"os"
@@ -23,7 +24,16 @@ func main() {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
 
-	processors := StartProcessors(ctx, appConfig)
+	processors, err := StartProcessors(ctx, appConfig)
+	if err != nil {
+		shutdown(ctx, cancel, processors)
+	}
+	// Indicate readiness
+	err = readiness.Ready(ctx, appConfig.ReadinessFilePath)
+	if err != nil {
+		shutdown(ctx, cancel, processors)
+	}
+	log.Println("Pubsub Adapter successfully started")
 
 	// block until we receive eqReceiptProcessor shutdown signal
 	select {
@@ -31,6 +41,44 @@ func main() {
 		log.Printf("OS Signal Received: %s", sig.String())
 	}
 
+	shutdown(ctx, cancel, processors)
+
+}
+
+func StartProcessors(ctx context.Context, cfg *config.Configuration) ([]*processor.Processor, error) {
+	processors := make([]*processor.Processor, 0)
+
+	// Start EQ receipt processing
+	eqReceiptProcessor, err := processor.NewEqReceiptProcessor(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	processors = append(processors, eqReceiptProcessor)
+
+	// Start offline receipt processing
+	offlineReceiptProcessor, err := processor.NewOfflineReceiptProcessor(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	processors = append(processors, offlineReceiptProcessor)
+
+	// Start PPO undelivered processing
+	ppoUndeliveredProcessor, err := processor.NewPpoUndeliveredProcessor(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	processors = append(processors, ppoUndeliveredProcessor)
+
+	// Start QM undelivered processing
+	qmUndeliveredProcessor, err := processor.NewQmUndeliveredProcessor(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	processors = append(processors, qmUndeliveredProcessor)
+	return processors, nil
+}
+
+func shutdown(ctx context.Context, cancel context.CancelFunc, processors []*processor.Processor) {
 	//cleanup for eqReceiptProcessor graceful shutdown
 	log.Printf("Shutting Down")
 
@@ -55,34 +103,4 @@ func main() {
 
 	log.Printf("CloseRabbit complete")
 	os.Exit(1)
-
-}
-
-func StartProcessors(ctx context.Context, cfg *config.Configuration) []*processor.Processor {
-	processors := make([]*processor.Processor, 0)
-
-	// Start EQ receipt processing
-	eqReceiptProcessor := processor.NewEqReceiptProcessor(ctx, cfg)
-	go eqReceiptProcessor.Consume(ctx)
-	go eqReceiptProcessor.Process(ctx)
-	processors = append(processors, eqReceiptProcessor)
-
-	// Start offline receipt processing
-	offlineReceiptProcessor := processor.NewOfflineReceiptProcessor(ctx, cfg)
-	go offlineReceiptProcessor.Consume(ctx)
-	go offlineReceiptProcessor.Process(ctx)
-	processors = append(processors, offlineReceiptProcessor)
-
-	// Start PPO undelivered processing
-	ppoUndeliveredProcessor := processor.NewPpoUndeliveredProcessor(ctx, cfg)
-	go ppoUndeliveredProcessor.Consume(ctx)
-	go ppoUndeliveredProcessor.Process(ctx)
-	processors = append(processors, ppoUndeliveredProcessor)
-
-	// Start QM undelivered processing
-	qmUndeliveredProcessor := processor.NewQmUndeliveredProcessor(ctx, cfg)
-	go qmUndeliveredProcessor.Consume(ctx)
-	go qmUndeliveredProcessor.Process(ctx)
-	processors = append(processors, qmUndeliveredProcessor)
-	return processors
 }

--- a/main.go
+++ b/main.go
@@ -29,11 +29,13 @@ func main() {
 
 	processors, err := StartProcessors(ctx, appConfig, errChan)
 	if err != nil {
+		log.Println(errors.Wrap(err, "Error starting processors"))
 		shutdown(ctx, cancel, processors)
 	}
 	// Indicate readiness
 	err = readiness.Ready(ctx, appConfig.ReadinessFilePath)
 	if err != nil {
+		log.Println(errors.Wrap(err, "Error indicating readiness"))
 		shutdown(ctx, cancel, processors)
 	}
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ func main() {
 	if err != nil {
 		shutdown(ctx, cancel, processors)
 	}
-	log.Println("PubSub Adapter successfully started")
 
 	// block until we receive eqReceiptProcessor shutdown signal
 	select {

--- a/main_test.go
+++ b/main_test.go
@@ -48,17 +48,17 @@ func TestMessageProcessing(t *testing.T) {
 		cfg.EqReceiptTopic, cfg.EqReceiptProject, cfg.ReceiptRoutingKey))
 
 	t.Run("Test Offline receipting", testMessageProcessing(
-		`{"dateTime": "2008-08-24T00:00:00Z", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
+		`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
 		`{"event":{"type":"RESPONSE_RECEIVED","source":"RECEIPT_SERVICE","channel":"INTEGRATION_TEST","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"response":{"questionnaireId":"01213213213","unreceipt":false}}}`,
 		cfg.OfflineReceiptTopic, cfg.OfflineReceiptProject, cfg.ReceiptRoutingKey))
 
 	t.Run("Test PPO undelivered mail", testMessageProcessing(
-		`{"dateTime": "2008-08-24T00:00:00Z", "transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
+		`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
 		`{"event":{"type":"UNDELIVERED_MAIL_REPORTED","source":"RECEIPT_SERVICE","channel":"PPO","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"fulfilmentInformation":{"caseRef":"0123456789","fulfilmentCode":"P_TEST_1"}}}`,
 		cfg.PpoUndeliveredTopic, cfg.PpoUndeliveredProject, cfg.UndeliveredRoutingKey))
 
 	t.Run("Test QM undelivered mail", testMessageProcessing(
-		`{"dateTime": "2008-08-24T00:00:00Z", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
+		`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
 		`{"event":{"type":"UNDELIVERED_MAIL_REPORTED","source":"RECEIPT_SERVICE","channel":"QM","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"fulfilmentInformation":{"questionnaireId":"01213213213"}}}`,
 		cfg.QmUndeliveredTopic, cfg.QmUndeliveredProject, cfg.UndeliveredRoutingKey))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -46,7 +46,7 @@ func TestEqReceipt(t *testing.T) {
 	eqReceiptMsg := `{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"tx_id": "abc123xxx", "questionnaire_id": "01213213213"}}`
 	expectedRabbitMessage := `{"event":{"type":"RESPONSE_RECEIVED","source":"RECEIPT_SERVICE","channel":"EQ","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"response":{"questionnaireId":"01213213213","unreceipt":false}}}`
 
-	if _, err := StartProcessors(ctx, cfg); err != nil {
+	if _, err := StartProcessors(ctx, cfg, make(chan error)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -86,7 +86,7 @@ func TestOfflineReceipt(t *testing.T) {
 	offlineReceiptMsg := `{"dateTime": "2008-08-24T00:00:00Z", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`
 	expectedRabbitMessage := `{"event":{"type":"RESPONSE_RECEIVED","source":"RECEIPT_SERVICE","channel":"INTEGRATION_TEST","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"response":{"questionnaireId":"01213213213","unreceipt":false}}}`
 
-	if _, err := StartProcessors(ctx, cfg); err != nil {
+	if _, err := StartProcessors(ctx, cfg, make(chan error)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -125,7 +125,7 @@ func TestPpoUndelivered(t *testing.T) {
 	ppoUndeliveredMsg := `{"dateTime": "2008-08-24T00:00:00Z", "transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`
 	expectedRabbitMessage := `{"event":{"type":"UNDELIVERED_MAIL_REPORTED","source":"RECEIPT_SERVICE","channel":"PPO","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"fulfilmentInformation":{"caseRef":"0123456789","fulfilmentCode":"P_TEST_1"}}}`
 
-	if _, err := StartProcessors(ctx, cfg); err != nil {
+	if _, err := StartProcessors(ctx, cfg, make(chan error)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -164,10 +164,11 @@ func TestQmUndelivered(t *testing.T) {
 	qmUndeliveredMsg := `{"dateTime": "2008-08-24T00:00:00Z", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`
 	expectedRabbitMessage := `{"event":{"type":"UNDELIVERED_MAIL_REPORTED","source":"RECEIPT_SERVICE","channel":"QM","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"fulfilmentInformation":{"questionnaireId":"01213213213"}}}`
 
-	if _, err := StartProcessors(ctx, cfg); err != nil {
+	if _, err := StartProcessors(ctx, cfg, make(chan error)); err != nil {
 		t.Error(err)
 		return
 	}
+
 
 	rabbitConn, rabbitChan, err := connectToRabbitChannel()
 	defer rabbitConn.Close()
@@ -199,7 +200,7 @@ func TestQmUndelivered(t *testing.T) {
 }
 
 func TestStartProcessors(t *testing.T) {
-	processors, err := StartProcessors(ctx, cfg)
+	processors, err := StartProcessors(ctx, cfg, make(chan error))
 	if err != nil {
 		t.Error(err)
 		return

--- a/main_test.go
+++ b/main_test.go
@@ -46,7 +46,11 @@ func TestEqReceipt(t *testing.T) {
 	eqReceiptMsg := `{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"tx_id": "abc123xxx", "questionnaire_id": "01213213213"}}`
 	expectedRabbitMessage := `{"event":{"type":"RESPONSE_RECEIVED","source":"RECEIPT_SERVICE","channel":"EQ","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"response":{"questionnaireId":"01213213213","unreceipt":false}}}`
 
-	_ = StartProcessors(ctx, cfg)
+	if _, err := StartProcessors(ctx, cfg); err != nil {
+		t.Error(err)
+		return
+	}
+
 
 	rabbitConn, rabbitChan, err := connectToRabbitChannel()
 	defer rabbitConn.Close()
@@ -82,7 +86,10 @@ func TestOfflineReceipt(t *testing.T) {
 	offlineReceiptMsg := `{"dateTime": "2008-08-24T00:00:00Z", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`
 	expectedRabbitMessage := `{"event":{"type":"RESPONSE_RECEIVED","source":"RECEIPT_SERVICE","channel":"INTEGRATION_TEST","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"response":{"questionnaireId":"01213213213","unreceipt":false}}}`
 
-	_ = StartProcessors(ctx, cfg)
+	if _, err := StartProcessors(ctx, cfg); err != nil {
+		t.Error(err)
+		return
+	}
 
 	rabbitConn, rabbitChan, err := connectToRabbitChannel()
 	defer rabbitConn.Close()
@@ -118,7 +125,10 @@ func TestPpoUndelivered(t *testing.T) {
 	ppoUndeliveredMsg := `{"dateTime": "2008-08-24T00:00:00Z", "transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`
 	expectedRabbitMessage := `{"event":{"type":"UNDELIVERED_MAIL_REPORTED","source":"RECEIPT_SERVICE","channel":"PPO","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"fulfilmentInformation":{"caseRef":"0123456789","fulfilmentCode":"P_TEST_1"}}}`
 
-	_ = StartProcessors(ctx, cfg)
+	if _, err := StartProcessors(ctx, cfg); err != nil {
+		t.Error(err)
+		return
+	}
 
 	rabbitConn, rabbitChan, err := connectToRabbitChannel()
 	defer rabbitConn.Close()
@@ -154,7 +164,10 @@ func TestQmUndelivered(t *testing.T) {
 	qmUndeliveredMsg := `{"dateTime": "2008-08-24T00:00:00Z", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`
 	expectedRabbitMessage := `{"event":{"type":"UNDELIVERED_MAIL_REPORTED","source":"RECEIPT_SERVICE","channel":"QM","dateTime":"2008-08-24T00:00:00Z","transactionId":"abc123xxx"},"payload":{"fulfilmentInformation":{"questionnaireId":"01213213213"}}}`
 
-	_ = StartProcessors(ctx, cfg)
+	if _, err := StartProcessors(ctx, cfg); err != nil {
+		t.Error(err)
+		return
+	}
 
 	rabbitConn, rabbitChan, err := connectToRabbitChannel()
 	defer rabbitConn.Close()
@@ -186,7 +199,11 @@ func TestQmUndelivered(t *testing.T) {
 }
 
 func TestStartProcessors(t *testing.T) {
-	processors := StartProcessors(ctx, cfg)
+	processors, err := StartProcessors(ctx, cfg)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	if len(processors) != 4 {
 		t.Errorf("StartProcessors should return 4 processors, actually returned %d", len(processors))

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt)
 }
 

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
-	return NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt)
+func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+	return NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt, errChan)
 }
 
 func unmarshalEqReceipt(data []byte) (models.PubSubMessage, error) {

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.OfflineReceiptProject, appConfig.OfflineReceiptSubscription, appConfig.ReceiptRoutingKey, convertOfflineReceiptToRmMessage, unmarshalOfflineReceipt)
 }
 

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
-	return NewProcessor(ctx, appConfig, appConfig.OfflineReceiptProject, appConfig.OfflineReceiptSubscription, appConfig.ReceiptRoutingKey, convertOfflineReceiptToRmMessage, unmarshalOfflineReceipt)
+func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+	return NewProcessor(ctx, appConfig, appConfig.OfflineReceiptProject, appConfig.OfflineReceiptSubscription, appConfig.ReceiptRoutingKey, convertOfflineReceiptToRmMessage, unmarshalOfflineReceipt, errChan)
 }
 
 func unmarshalOfflineReceipt(data []byte) (models.PubSubMessage, error) {

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
-	return NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered)
+func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+	return NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered, errChan)
 }
 
 func unmarshalPpoUndelivered(data []byte) (models.PubSubMessage, error) {

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered)
 }
 

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) *Processor {
+func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.QmUndeliveredProject, appConfig.QmUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertQmUndeliveredToRmMessage, unmarshalQmUndelivered)
 }
 

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -9,8 +9,8 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration) (*Processor, error) {
-	return NewProcessor(ctx, appConfig, appConfig.QmUndeliveredProject, appConfig.QmUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertQmUndeliveredToRmMessage, unmarshalQmUndelivered)
+func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+	return NewProcessor(ctx, appConfig, appConfig.QmUndeliveredProject, appConfig.QmUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertQmUndeliveredToRmMessage, unmarshalQmUndelivered, errChan)
 }
 
 func unmarshalQmUndelivered(data []byte) (models.PubSubMessage, error) {

--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -43,15 +43,6 @@ spec:
             periodSeconds: 2
             failureThreshold: 10
             successThreshold: 1
-          livenessProbe:
-            exec:
-              command:
-                - cat
-                - $(READINESS_FILE_PATH)
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
           volumeMounts:
             - name: gcp-credentials-volume
               mountPath: /gcp-credentials

--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -80,14 +80,14 @@ spec:
                 configMapKeyRef:
                   name: project-config
                   key: project-name
-            - name: PPO_UNDELIVERED_SUBSCRIPTION_NAME
+            - name: PPO_UNDELIVERED_SUBSCRIPTION
               value: "rm-ppo-undelivered-subscription"
             - name: PPO_UNDELIVERED_SUBSCRIPTION_PROJECT
               valueFrom:
                 configMapKeyRef:
                   name: project-config
                   key: project-name
-            - name: QM_UNDELIVERED_SUBSCRIPTION_NAME
+            - name: QM_UNDELIVERED_SUBSCRIPTION
               value: "rm-qm-undelivered-subscription"
             - name: QM_UNDELIVERED_SUBSCRIPTION_PROJECT
               valueFrom:

--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -34,6 +34,24 @@ spec:
             limits:
               cpu: "0.4"
               memory: "64Mi"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - $(READINESS_FILE_PATH)
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 10
+            successThreshold: 1
+          livenessProbe:
+            exec:
+              command:
+                - cat
+                - $(READINESS_FILE_PATH)
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
             - name: gcp-credentials-volume
               mountPath: /gcp-credentials
@@ -92,6 +110,8 @@ spec:
                 secretKeyRef:
                   name: rabbitmq
                   key: rabbitmq-password
+            - name: READINESS_FILE_PATH
+              value: "/tmp/pubsub-adapter-ready"
       volumes:
         - name: gcp-credentials-volume
           secret:

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -24,12 +24,10 @@ func Ready(ctx context.Context, readinessFilePath string) error {
 }
 
 func removeReadyWhenDone(ctx context.Context, readinessFilePath string) {
-	select {
-	case <-ctx.Done():
-		log.Println("Removing readiness file")
+	<-ctx.Done()
+	        log.Println("Removing readiness file")
 		err := os.Remove(readinessFilePath)
 		if err != nil {
 			log.Println(errors.Wrap(err, fmt.Sprintf("Error removing readiness file: %s", readinessFilePath)))
 		}
-	}
 }

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -1,0 +1,35 @@
+package readiness
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"log"
+	"os"
+)
+
+func Ready(ctx context.Context, readinessFilePath string) error {
+	_, err := os.Stat(readinessFilePath)
+	if err == nil {
+		// TODO Log a warning that the readiness file already existed
+		log.Println("Readiness file already existed")
+	}
+	_, err = os.Create(readinessFilePath)
+	if err != nil {
+		return err
+	}
+	go removeReadyWhenDone(ctx, readinessFilePath)
+
+	return nil
+}
+
+func removeReadyWhenDone(ctx context.Context, readinessFilePath string) {
+	select {
+	case <-ctx.Done():
+		log.Println("Removing readiness file")
+		err := os.Remove(readinessFilePath)
+		if err != nil {
+			log.Println(errors.Wrap(err, fmt.Sprintf("Error removing readiness file: %s", readinessFilePath)))
+		}
+	}
+}

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -25,9 +25,9 @@ func Ready(ctx context.Context, readinessFilePath string) error {
 
 func removeReadyWhenDone(ctx context.Context, readinessFilePath string) {
 	<-ctx.Done()
-	        log.Println("Removing readiness file")
-		err := os.Remove(readinessFilePath)
-		if err != nil {
-			log.Println(errors.Wrap(err, fmt.Sprintf("Error removing readiness file: %s", readinessFilePath)))
-		}
+	log.Println("Removing readiness file")
+	err := os.Remove(readinessFilePath)
+	if err != nil {
+		log.Println(errors.Wrap(err, fmt.Sprintf("Error removing readiness file: %s", readinessFilePath)))
+	}
 }

--- a/readiness/readiness_test.go
+++ b/readiness/readiness_test.go
@@ -49,7 +49,9 @@ func testReadinessFiles(t *testing.T) {
 	// Set a timeout for if the readiness file is not deleted
 	timeoutCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 
+	// Trigger the cancel which should result in the file being removed
 	cancel()
+
 	for {
 		// Check if readiness file has been removed
 		if _, err = os.Stat(readinessFilePath); err != nil {
@@ -59,6 +61,8 @@ func testReadinessFiles(t *testing.T) {
 			t.Error(err)
 			return
 		}
+
+		// Fail the test if it times out before the file is removed
 		select {
 		case <-timeoutCtx.Done():
 			t.Error("Test timed out waiting for file cleanup")

--- a/readiness/readiness_test.go
+++ b/readiness/readiness_test.go
@@ -1,0 +1,78 @@
+package readiness
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+var testDir = "tmpTest"
+var readinessFilePath = testDir + "/test-ready"
+
+func TestReady(t *testing.T) {
+	err := setupTestDirectory()
+	if err != nil {
+		t.Error("Error setting up tmp test directory", err)
+		return
+	}
+
+	t.Run("Test readiness file is produced and removed", testReadinessFiles)
+
+	err = os.RemoveAll(testDir)
+	if err != nil {
+		t.Error(err)
+	}
+
+}
+
+func testReadinessFiles(t *testing.T) {
+	// Given
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+
+	// When
+	err := Ready(ctx, readinessFilePath)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Then
+	// Check the readiness file is created
+	_, err = os.Stat(readinessFilePath)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Set a timeout for if the readiness file is not deleted
+	timeoutCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+
+	cancel()
+	for {
+		// Check if readiness file has been removed
+		if _, err = os.Stat(readinessFilePath); err != nil {
+			if os.IsNotExist(err) {
+				return
+			}
+			t.Error(err)
+			return
+		}
+		select {
+		case <-timeoutCtx.Done():
+			t.Error("Test timed out waiting for file cleanup")
+			return
+		default:
+		}
+
+	}
+}
+
+func setupTestDirectory() error {
+	err := os.RemoveAll(testDir)
+	if err != nil {
+		return err
+	}
+	return os.Mkdir(testDir, 0700)
+}


### PR DESCRIPTION
# Motivation and Context
K8s needs a readiness probe to know when the app has successfully started.
The app also needs to handle it gracefully if one of it's consumers dies.

# What has changed
* Add readiness indicator by presence of file
* Add readiness and liveness probe to dev k8s manifest
* Add healthcheck to docker compose
* Gracefully shutdown app if a pubsub receiver errors
* Refactor integration tests 

# How to test?
Deploy the app to your dev k8s. Manually edit the pubsub or rabbit config so it cannot start up properly. You shoud see the app does not show as ready when it cannot start correctly.

# Links
https://trello.com/c/OdlCJqh4/901-pubsub-adapter-readiness-liveness-probes-8