### PR TITLE
Structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ PPO_UNDELIVERED_SUBSCRIPTION_PROJECT
 ### Config to run locally against docker-compose dependencies
 
 ```sh 
+LOG_LEVEL=DEBUG
 RABBIT_HOST=localhost
 RABBIT_PORT=7672
 RABBIT_USERNAME=guest
@@ -40,6 +41,7 @@ UNDELIVERED_ROUTING_KEY=goTestUndeliveredQueue
 ### Config to run locally against docker dev
 
 ```sh 
+LOG_LEVEL=INFO
 RABBIT_HOST=localhost
 RABBIT_PORT=6672
 RABBIT_USERNAME=guest

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 type Configuration struct {
 	ReadinessFilePath string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
+	LogLevel          string `envconfig:"LOG_LEVEL" default:"ERROR"`
 
 	// Rabbit
 	RabbitHost             string `envconfig:"RABBIT_HOST" required:"true"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - OFFLINE_RECEIPT_PROJECT=offline-project
       - QM_UNDELIVERED_SUBSCRIPTION_PROJECT=qm-undelivered-project
       - PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
+      - LOG_LEVEL=INFO
     restart: on-failure
     healthcheck:
       test: ["CMD", "find", "/tmp/pubsub-adapter-ready", "-mmin", "-1"]

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71
+	go.uber.org/zap v1.15.0
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -91,6 +92,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -99,12 +101,20 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71 h1:2MR0pKUzlP3SGgj5NYJe/zRYDwOu9ku6YHy+Iw7l5DM=
 github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
+go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
+go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
+go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
+go.uber.org/zap v1.15.0 h1:ZZCA22JRF2gQE5FoNmhmrf7jeJJ2uhqDUNRYKm8dvmM=
+go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -213,6 +223,8 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,14 +4,13 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"strings"
 )
 
 var Logger *zap.SugaredLogger
 
 func getZapLevel(textLevel string) (zap.AtomicLevel, error) {
 	level := zap.AtomicLevel{}
-	err := level.UnmarshalText([]byte(strings.ToLower(textLevel)))
+	err := level.UnmarshalText([]byte(textLevel))
 	return level, err
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,52 @@
+package logger
+
+import (
+	"github.com/ONSdigital/census-rm-pubsub-adapter/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"strings"
+)
+
+var Logger *zap.SugaredLogger
+
+func getZapLevel(textLevel string) (zap.AtomicLevel, error) {
+	level := zap.AtomicLevel{}
+	err := level.UnmarshalText([]byte(strings.ToLower(textLevel)))
+	return level, err
+}
+
+func init() {
+	// Initialise a default dev logger
+	initLogger, _ := zap.NewDevelopment()
+	Logger = initLogger.Sugar()
+}
+
+func ConfigureLogger(cfg *config.Configuration) error {
+	logLevel, err := getZapLevel(cfg.LogLevel)
+	if err != nil {
+		return err
+	}
+	initLogger, err := zap.Config{
+		Encoding:         "json",
+		Level:            logLevel,
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stdout"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey: "message",
+
+			LevelKey:    "severity",
+			EncodeLevel: zapcore.CapitalLevelEncoder,
+
+			TimeKey:    "timestamp",
+			EncodeTime: zapcore.RFC3339NanoTimeEncoder,
+
+			CallerKey:    "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		}}.Build()
+	if err != nil {
+		return err
+	}
+	defer Logger.Sync()
+	Logger = initLogger.Sugar()
+	return nil
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"reflect"
+	"testing"
+)
+
+func TestGetZapLevel(t *testing.T) {
+	t.Run("Test INFO", testGetZapLevel("INFO", zap.InfoLevel))
+	t.Run("Test DEBUG", testGetZapLevel("DEBUG", zap.DebugLevel))
+	t.Run("Test ERROR", testGetZapLevel("ERROR", zap.ErrorLevel))
+	t.Run("Test WARN", testGetZapLevel("WARN", zap.WarnLevel))
+}
+
+func testGetZapLevel(levelString string, expectedLevel zapcore.Level) func(*testing.T) {
+	return func(t *testing.T) {
+		level, err := getZapLevel(levelString)
+		if err != nil {
+			t.Error(err)
+		}
+		if reflect.DeepEqual(level, expectedLevel) {
+			t.Errorf("Level: %s doesn't match expected level: %s", level, expectedLevel)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	// Block until we receive OS shutdown signal or error
 	select {
 	case sig := <-signals:
-		logger.Logger.Errorw("OS Signal Received", "signal", sig.String())
+		logger.Logger.Infow("OS Signal Received", "signal", sig.String())
 	case err := <-errChan:
 		logger.Logger.Errorw("Error Received", "error", err)
 	}
@@ -95,7 +95,7 @@ func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan cha
 
 func shutdown(ctx context.Context, cancel context.CancelFunc, processors []*processor.Processor) {
 	// cleanup for graceful shutdown
-	logger.Logger.Error("Shutting Down")
+	logger.Logger.Info("Shutting Down")
 
 	// give the app 10 sec to cleanup before being killed
 	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -116,6 +116,6 @@ func shutdown(ctx context.Context, cancel context.CancelFunc, processors []*proc
 	//block until shutdown cancel has been called
 	<-shutdownCtx.Done()
 
-	logger.Logger.Error("Shutdown complete")
+	logger.Logger.Info("Shutdown complete")
 	os.Exit(1)
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	// Block until we receive OS shutdown signal or error
 	select {
 	case sig := <-signals:
-		logger.Logger.Infow("OS Signal Received", "signal", sig.String())
+		logger.Logger.Errorw("OS Signal Received", "signal", sig.String())
 	case err := <-errChan:
 		logger.Logger.Errorw("Error Received", "error", err)
 	}
@@ -95,7 +95,7 @@ func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan cha
 
 func shutdown(ctx context.Context, cancel context.CancelFunc, processors []*processor.Processor) {
 	// cleanup for graceful shutdown
-	logger.Logger.Warn("Shutting Down")
+	logger.Logger.Error("Shutting Down")
 
 	// give the app 10 sec to cleanup before being killed
 	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 10*time.Second)

--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -103,6 +103,8 @@ spec:
                   key: rabbitmq-password
             - name: READINESS_FILE_PATH
               value: "/tmp/pubsub-adapter-ready"
+            - name: LOG_LEVEL
+              value: "INFO"
       volumes:
         - name: gcp-credentials-volume
           secret:

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -2,17 +2,14 @@ package readiness
 
 import (
 	"context"
-	"fmt"
-	"github.com/pkg/errors"
-	"log"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/logger"
 	"os"
 )
 
 func Ready(ctx context.Context, readinessFilePath string) error {
 	_, err := os.Stat(readinessFilePath)
 	if err == nil {
-		// TODO Log a warning that the readiness file already existed
-		log.Println("Readiness file already existed")
+		logger.Logger.Errorw("Readiness file already existed", "readinessFilePath", readinessFilePath)
 	}
 	_, err = os.Create(readinessFilePath)
 	if err != nil {
@@ -25,9 +22,9 @@ func Ready(ctx context.Context, readinessFilePath string) error {
 
 func removeReadyWhenDone(ctx context.Context, readinessFilePath string) {
 	<-ctx.Done()
-	log.Println("Removing readiness file")
+	logger.Logger.Info("Removing readiness file")
 	err := os.Remove(readinessFilePath)
 	if err != nil {
-		log.Println(errors.Wrap(err, fmt.Sprintf("Error removing readiness file: %s", readinessFilePath)))
+		logger.Logger.Errorw("Error removing readiness file", "readinessFilePath", readinessFilePath, "error", err)
 	}
 }


### PR DESCRIPTION
# Motivation and Context
We need the pubsub adapter to use structured logging so that log entries can be searched on and used for metrics in GKE/stackdriver/grafana.

# What has changed
* Configure zap structured logger at startup
* Use zap structured logging
* Add LOG_LEVEL environment variable to set the service log level

# How to test?
Try running the service at different log levels (e.g. INFO, DEBUG, WARN, ERROR).

# Links
https://trello.com/c/OXBw9jhY/908-pubsub-adapter-structured-logging-5

## Screenshots
Example of the structured log viewed in stackdriver, shown with the right severity and the json fields showing up as expected
![Screenshot 2020-05-06 at 14 22 05](https://user-images.githubusercontent.com/35268982/81181918-071df100-8fa5-11ea-88f3-01144b7f7789.png)

