### PR TITLE
Quarantine messages we can't unmarshal in rabbit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:alpine as builder
 RUN mkdir /build
 ADD . /build/
 WORKDIR /build
+RUN go mod download && go mod verify
 RUN go build -o main .
 FROM alpine
 RUN adduser -S -D -H -h /app appuser

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ unit-test:
 	go test -race ./... -tags=unitTest
 
 run-int-test:
-	PUBSUB_EMULATOR_HOST=localhost:8539 go test github.com/ONSdigital/census-rm-pubsub-adapter
+	PUBSUB_EMULATOR_HOST=localhost:8539 go test -count 1 github.com/ONSdigital/census-rm-pubsub-adapter
 
 int-test: down up-dependencies run-int-test down
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Configuration struct {
 	EventsExchange         string `envconfig:"RABBIT_EXCHANGE"  default:"events"`
 	ReceiptRoutingKey      string `envconfig:"RECEIPT_ROUTING_KEY"  default:"event.response.receipt"`
 	UndeliveredRoutingKey  string `envconfig:"UNDELIVERED_ROUTING_KEY"  default:"event.fulfilment.undelivered"`
+	DlqRoutingKey          string `envconfig:"DLQ_ROUTING_KEY"  default:"pubsub.quarantine"`
 
 	// PubSub
 	EqReceiptProject           string `envconfig:"EQ_RECEIPT_PROJECT" required:"true"`

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	cloud.google.com/go/pubsub v1.3.1
+	github.com/go-playground/validator/v10 v10.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/streadway/amqp v0.0.0-20200108173154-1c71cc93ed71

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,14 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp4Mit+3FDh548oRqwVgNsHA=
+github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
+github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -92,6 +100,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func main() {
 	case sig := <-signals:
 		logger.Logger.Infow("OS Signal Received", "signal", sig.String())
 	case err := <-errChan:
+		// TODO This is a temporary solution, it is not ideal because an error in any one of the consumers will kill them all
 		logger.Logger.Errorw("Error Received", "error", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	case sig := <-signals:
 		logger.Logger.Infow("OS Signal Received", "signal", sig.String())
 	case err := <-errChan:
-		// TODO This is a temporary solution, it is not ideal because an error in any one of the consumers will kill them all
+		// TODO Make some attempt to restart receivers so one error doesn't kill them all immediately
 		logger.Logger.Errorw("Error Received", "error", err)
 	}
 

--- a/models/eqReceipt.go
+++ b/models/eqReceipt.go
@@ -12,7 +12,7 @@ type EqReceiptMetadata struct {
 }
 
 type EqReceipt struct {
-	TimeCreated time.Time         `json:"timeCreated"`
+	TimeCreated *time.Time        `json:"timeCreated"`
 	Metadata    EqReceiptMetadata `json:"metadata"`
 }
 
@@ -24,7 +24,7 @@ func (e EqReceipt) Validate() error {
 	if e.GetTransactionId() == "" {
 		return errors.New("EqReceipt missing transaction ID")
 	}
-	if e.TimeCreated.IsZero() {
+	if e.TimeCreated == nil {
 		return errors.New("EqReceipt missing timeCreated")
 	}
 	if e.Metadata.QuestionnaireId == "" {

--- a/models/eqReceipt.go
+++ b/models/eqReceipt.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"time"
 )
 
@@ -19,6 +20,15 @@ func (e EqReceipt) GetTransactionId() string {
 	return e.Metadata.TransactionId
 }
 
-func (e EqReceipt) Validate() bool {
-	return e.GetTransactionId() != ""
+func (e EqReceipt) Validate() error {
+	if e.GetTransactionId() == "" {
+		return errors.New("EqReceipt missing transaction ID")
+	}
+	if e.TimeCreated.IsZero() {
+		return errors.New("EqReceipt missing timeCreated")
+	}
+	if e.Metadata.QuestionnaireId == "" {
+		return errors.New("EqReceipt missing questionnaire ID")
+	}
+	return nil
 }

--- a/models/eqReceipt.go
+++ b/models/eqReceipt.go
@@ -1,19 +1,19 @@
 package models
 
 import (
-	"errors"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/validate"
 	"time"
 )
 
 type EqReceiptMetadata struct {
-	TransactionId   string `json:"tx_id"`
-	QuestionnaireId string `json:"questionnaire_id"`
+	TransactionId   string `json:"tx_id" validate:"required"`
+	QuestionnaireId string `json:"questionnaire_id" validate:"required"`
 	CaseID          string `json:"caseId,omitempty"`
 }
 
 type EqReceipt struct {
-	TimeCreated *time.Time        `json:"timeCreated"`
-	Metadata    EqReceiptMetadata `json:"metadata"`
+	TimeCreated *time.Time        `json:"timeCreated" validate:"required"`
+	Metadata    EqReceiptMetadata `json:"metadata" validate:"required"`
 }
 
 func (e EqReceipt) GetTransactionId() string {
@@ -21,14 +21,5 @@ func (e EqReceipt) GetTransactionId() string {
 }
 
 func (e EqReceipt) Validate() error {
-	if e.GetTransactionId() == "" {
-		return errors.New("EqReceipt missing transaction ID")
-	}
-	if e.TimeCreated == nil {
-		return errors.New("EqReceipt missing timeCreated")
-	}
-	if e.Metadata.QuestionnaireId == "" {
-		return errors.New("EqReceipt missing questionnaire ID")
-	}
-	return nil
+	return validate.Validate.Struct(e)
 }

--- a/models/eqReceipt.go
+++ b/models/eqReceipt.go
@@ -1,6 +1,8 @@
 package models
 
-import "time"
+import (
+	"time"
+)
 
 type EqReceiptMetadata struct {
 	TransactionId   string `json:"tx_id"`
@@ -15,4 +17,8 @@ type EqReceipt struct {
 
 func (e EqReceipt) GetTransactionId() string {
 	return e.Metadata.TransactionId
+}
+
+func (e EqReceipt) Validate() bool {
+	return e.GetTransactionId() != ""
 }

--- a/models/eqReceipt_test.go
+++ b/models/eqReceipt_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 )
 
@@ -10,28 +9,28 @@ func TestEqReceipt_Validate(t *testing.T) {
 
 	t.Run("Validate good EqReceipt",
 		testEqReceiptValidate(`{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"tx_id": "abc123xxx", "questionnaire_id": "01213213213"}}`,
-			nil))
+			true))
 	t.Run("Validate missing questionnaire ID",
 		testEqReceiptValidate(`{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"tx_id": "abc123xxx"}}`,
-			errors.New("EqReceipt missing questionnaire ID")))
+			false))
 	t.Run("Validate missing time created",
 		testEqReceiptValidate(`{"metadata": {"tx_id": "abc123xxx", "questionnaire_id": "01213213213"}}`,
-			errors.New("EqReceipt missing timeCreated")))
+			false))
 	t.Run("Validate missing transaction ID",
 		testEqReceiptValidate(`{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"questionnaire_id": "01213213213"}}`,
-			errors.New("EqReceipt missing transaction ID")))
+			false))
 
 }
 
-func testEqReceiptValidate(msgJson string, expectedErr error) func(*testing.T) {
+func testEqReceiptValidate(msgJson string, valid bool) func(*testing.T) {
 	return func(t *testing.T) {
 		eqReceipt := EqReceipt{}
 		if err := json.Unmarshal([]byte(msgJson), &eqReceipt); err != nil {
 			t.Error(err)
 			return
 		}
-		if err := eqReceipt.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
-			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		if err := eqReceipt.Validate(); !valid && err == nil || valid && err != nil {
+			t.Errorf("Got err: %s", err)
 		}
 	}
 }

--- a/models/eqReceipt_test.go
+++ b/models/eqReceipt_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestEqReceipt_Validate(t *testing.T) {
+
+	t.Run("Validate good EqReceipt",
+		testEqReceiptValidate(`{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"tx_id": "abc123xxx", "questionnaire_id": "01213213213"}}`,
+			nil))
+	t.Run("Validate missing questionnaire ID",
+		testEqReceiptValidate(`{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"tx_id": "abc123xxx"}}`,
+			errors.New("EqReceipt missing questionnaire ID")))
+	t.Run("Validate missing time created",
+		testEqReceiptValidate(`{"metadata": {"tx_id": "abc123xxx", "questionnaire_id": "01213213213"}}`,
+			errors.New("EqReceipt missing timeCreated")))
+	t.Run("Validate missing transaction ID",
+		testEqReceiptValidate(`{"timeCreated": "2008-08-24T00:00:00Z", "metadata": {"questionnaire_id": "01213213213"}}`,
+			errors.New("EqReceipt missing transaction ID")))
+
+}
+
+func testEqReceiptValidate(msgJson string, expectedErr error) func(*testing.T) {
+	return func(t *testing.T) {
+		eqReceipt := EqReceipt{}
+		if err := json.Unmarshal([]byte(msgJson), &eqReceipt); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := eqReceipt.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
+			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		}
+	}
+}

--- a/models/offlineReceipt.go
+++ b/models/offlineReceipt.go
@@ -1,5 +1,7 @@
 package models
 
+import "errors"
+
 type OfflineReceipt struct {
 	TimeCreated     HazyUtcTime `json:"dateTime"`
 	TransactionId   string      `json:"transactionId"`
@@ -12,6 +14,15 @@ func (o OfflineReceipt) GetTransactionId() string {
 	return o.TransactionId
 }
 
-func (o OfflineReceipt) Validate() bool {
-	return o.GetTransactionId() != ""
+func (o OfflineReceipt) Validate() error {
+	if o.GetTransactionId() == "" {
+		return errors.New("OfflineReceipt missing transaction ID")
+	}
+	if o.TimeCreated.IsZero() {
+		return errors.New("OfflineReceipt missing dateTime")
+	}
+	if o.QuestionnaireId == "" {
+		return errors.New("OfflineReceipt missing questionnaire ID")
+	}
+	return nil
 }

--- a/models/offlineReceipt.go
+++ b/models/offlineReceipt.go
@@ -1,11 +1,13 @@
 package models
 
-import "errors"
+import (
+	"github.com/ONSdigital/census-rm-pubsub-adapter/validate"
+)
 
 type OfflineReceipt struct {
-	TimeCreated     *HazyUtcTime `json:"dateTime"`
-	TransactionId   string       `json:"transactionId"`
-	QuestionnaireId string       `json:"questionnaireId"`
+	TimeCreated     *HazyUtcTime `json:"dateTime" validate:"required"`
+	TransactionId   string       `json:"transactionId" validate:"required"`
+	QuestionnaireId string       `json:"questionnaireId" validate:"required"`
 	Unreceipt       bool         `json:"unreceipt"`
 	Channel         string       `json:"channel"`
 }
@@ -15,14 +17,5 @@ func (o OfflineReceipt) GetTransactionId() string {
 }
 
 func (o OfflineReceipt) Validate() error {
-	if o.GetTransactionId() == "" {
-		return errors.New("OfflineReceipt missing transaction ID")
-	}
-	if o.TimeCreated == nil {
-		return errors.New("OfflineReceipt missing dateTime")
-	}
-	if o.QuestionnaireId == "" {
-		return errors.New("OfflineReceipt missing questionnaire ID")
-	}
-	return nil
+	return validate.Validate.Struct(o)
 }

--- a/models/offlineReceipt.go
+++ b/models/offlineReceipt.go
@@ -11,3 +11,7 @@ type OfflineReceipt struct {
 func (o OfflineReceipt) GetTransactionId() string {
 	return o.TransactionId
 }
+
+func (o OfflineReceipt) Validate() bool {
+	return o.GetTransactionId() != ""
+}

--- a/models/offlineReceipt.go
+++ b/models/offlineReceipt.go
@@ -3,11 +3,11 @@ package models
 import "errors"
 
 type OfflineReceipt struct {
-	TimeCreated     HazyUtcTime `json:"dateTime"`
-	TransactionId   string      `json:"transactionId"`
-	QuestionnaireId string      `json:"questionnaireId"`
-	Unreceipt       bool        `json:"unreceipt"`
-	Channel         string      `json:"channel"`
+	TimeCreated     *HazyUtcTime `json:"dateTime"`
+	TransactionId   string       `json:"transactionId"`
+	QuestionnaireId string       `json:"questionnaireId"`
+	Unreceipt       bool         `json:"unreceipt"`
+	Channel         string       `json:"channel"`
 }
 
 func (o OfflineReceipt) GetTransactionId() string {
@@ -18,7 +18,7 @@ func (o OfflineReceipt) Validate() error {
 	if o.GetTransactionId() == "" {
 		return errors.New("OfflineReceipt missing transaction ID")
 	}
-	if o.TimeCreated.IsZero() {
+	if o.TimeCreated == nil {
 		return errors.New("OfflineReceipt missing dateTime")
 	}
 	if o.QuestionnaireId == "" {

--- a/models/offlineReceipt_test.go
+++ b/models/offlineReceipt_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 )
 
@@ -10,28 +9,28 @@ func TestOfflineReceipt_Validate(t *testing.T) {
 
 	t.Run("Validate good OfflineReceipt",
 		testOfflineReceiptValidate(`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
-			nil))
+			true))
 	t.Run("Validate missing questionnaire ID",
 		testOfflineReceiptValidate(`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx"}`,
-			errors.New("OfflineReceipt missing questionnaire ID")))
+			false))
 	t.Run("Validate missing time created",
 		testOfflineReceiptValidate(`{"unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
-			errors.New("OfflineReceipt missing dateTime")))
+			false))
 	t.Run("Validate missing transaction ID",
 		testOfflineReceiptValidate(`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "questionnaireId": "01213213213"}`,
-			errors.New("OfflineReceipt missing transaction ID")))
+			false))
 
 }
 
-func testOfflineReceiptValidate(msgJson string, expectedErr error) func(*testing.T) {
+func testOfflineReceiptValidate(msgJson string, valid bool) func(*testing.T) {
 	return func(t *testing.T) {
 		offlineReceipt := OfflineReceipt{}
 		if err := json.Unmarshal([]byte(msgJson), &offlineReceipt); err != nil {
 			t.Error(err)
 			return
 		}
-		if err := offlineReceipt.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
-			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		if err := offlineReceipt.Validate(); !valid && err == nil || valid && err != nil {
+			t.Errorf("Got err: %s", err)
 		}
 	}
 }

--- a/models/offlineReceipt_test.go
+++ b/models/offlineReceipt_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestOfflineReceipt_Validate(t *testing.T) {
+
+	t.Run("Validate good OfflineReceipt",
+		testOfflineReceiptValidate(`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
+			nil))
+	t.Run("Validate missing questionnaire ID",
+		testOfflineReceiptValidate(`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx"}`,
+			errors.New("OfflineReceipt missing questionnaire ID")))
+	t.Run("Validate missing time created",
+		testOfflineReceiptValidate(`{"unreceipt" : false, "channel" : "INTEGRATION_TEST", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
+			errors.New("OfflineReceipt missing dateTime")))
+	t.Run("Validate missing transaction ID",
+		testOfflineReceiptValidate(`{"dateTime": "2008-08-24T00:00:00", "unreceipt" : false, "channel" : "INTEGRATION_TEST", "questionnaireId": "01213213213"}`,
+			errors.New("OfflineReceipt missing transaction ID")))
+
+}
+
+func testOfflineReceiptValidate(msgJson string, expectedErr error) func(*testing.T) {
+	return func(t *testing.T) {
+		offlineReceipt := OfflineReceipt{}
+		if err := json.Unmarshal([]byte(msgJson), &offlineReceipt); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := offlineReceipt.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
+			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		}
+	}
+}

--- a/models/ppoUndelivered.go
+++ b/models/ppoUndelivered.go
@@ -3,10 +3,10 @@ package models
 import "errors"
 
 type PpoUndelivered struct {
-	TransactionId string      `json:"transactionId"`
-	DateTime      HazyUtcTime `json:"dateTime"`
-	CaseRef       string      `json:"caseRef"`
-	ProductCode   string      `json:"productCode"`
+	TransactionId string       `json:"transactionId"`
+	DateTime      *HazyUtcTime `json:"dateTime"`
+	CaseRef       string       `json:"caseRef"`
+	ProductCode   string       `json:"productCode"`
 }
 
 func (p PpoUndelivered) GetTransactionId() string {
@@ -17,7 +17,7 @@ func (p PpoUndelivered) Validate() error {
 	if p.GetTransactionId() == "" {
 		return errors.New("PpoUndelivered missing transaction ID")
 	}
-	if p.DateTime.IsZero() {
+	if p.DateTime == nil {
 		return errors.New("PpoUndelivered missing dateTime")
 	}
 	if p.CaseRef == "" {

--- a/models/ppoUndelivered.go
+++ b/models/ppoUndelivered.go
@@ -10,3 +10,7 @@ type PpoUndelivered struct {
 func (p PpoUndelivered) GetTransactionId() string {
 	return p.TransactionId
 }
+
+func (p PpoUndelivered) Validate() bool {
+	return p.GetTransactionId() != ""
+}

--- a/models/ppoUndelivered.go
+++ b/models/ppoUndelivered.go
@@ -1,11 +1,13 @@
 package models
 
-import "errors"
+import (
+	"github.com/ONSdigital/census-rm-pubsub-adapter/validate"
+)
 
 type PpoUndelivered struct {
-	TransactionId string       `json:"transactionId"`
-	DateTime      *HazyUtcTime `json:"dateTime"`
-	CaseRef       string       `json:"caseRef"`
+	TransactionId string       `json:"transactionId" validate:"required"`
+	DateTime      *HazyUtcTime `json:"dateTime" validate:"required"`
+	CaseRef       string       `json:"caseRef" validate:"required"`
 	ProductCode   string       `json:"productCode"`
 }
 
@@ -14,14 +16,5 @@ func (p PpoUndelivered) GetTransactionId() string {
 }
 
 func (p PpoUndelivered) Validate() error {
-	if p.GetTransactionId() == "" {
-		return errors.New("PpoUndelivered missing transaction ID")
-	}
-	if p.DateTime == nil {
-		return errors.New("PpoUndelivered missing dateTime")
-	}
-	if p.CaseRef == "" {
-		return errors.New("PpoUndelivered missing case ref")
-	}
-	return nil
+	return validate.Validate.Struct(p)
 }

--- a/models/ppoUndelivered.go
+++ b/models/ppoUndelivered.go
@@ -1,5 +1,7 @@
 package models
 
+import "errors"
+
 type PpoUndelivered struct {
 	TransactionId string      `json:"transactionId"`
 	DateTime      HazyUtcTime `json:"dateTime"`
@@ -11,6 +13,15 @@ func (p PpoUndelivered) GetTransactionId() string {
 	return p.TransactionId
 }
 
-func (p PpoUndelivered) Validate() bool {
-	return p.GetTransactionId() != ""
+func (p PpoUndelivered) Validate() error {
+	if p.GetTransactionId() == "" {
+		return errors.New("PpoUndelivered missing transaction ID")
+	}
+	if p.DateTime.IsZero() {
+		return errors.New("PpoUndelivered missing dateTime")
+	}
+	if p.CaseRef == "" {
+		return errors.New("PpoUndelivered missing case ref")
+	}
+	return nil
 }

--- a/models/ppoUndelivered_test.go
+++ b/models/ppoUndelivered_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestPpoUndelivered_Validate(t *testing.T) {
+
+	t.Run("Validate good PpoUndelivered",
+		testPpoUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
+			nil))
+	t.Run("Validate missing case ref",
+		testPpoUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "productCode": "P_TEST_1"}`,
+			errors.New("PpoUndelivered missing case ref")))
+	t.Run("Validate missing dateTime",
+		testPpoUndeliveredValidate(`{"transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
+			errors.New("PpoUndelivered missing dateTime")))
+	t.Run("Validate missing transaction ID",
+		testPpoUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
+			errors.New("PpoUndelivered missing transaction ID")))
+
+}
+
+func testPpoUndeliveredValidate(msgJson string, expectedErr error) func(*testing.T) {
+	return func(t *testing.T) {
+		ppoUndelivered := PpoUndelivered{}
+		if err := json.Unmarshal([]byte(msgJson), &ppoUndelivered); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := ppoUndelivered.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
+			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		}
+	}
+}

--- a/models/ppoUndelivered_test.go
+++ b/models/ppoUndelivered_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 )
 
@@ -10,28 +9,28 @@ func TestPpoUndelivered_Validate(t *testing.T) {
 
 	t.Run("Validate good PpoUndelivered",
 		testPpoUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
-			nil))
+			true))
 	t.Run("Validate missing case ref",
 		testPpoUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "productCode": "P_TEST_1"}`,
-			errors.New("PpoUndelivered missing case ref")))
+			false))
 	t.Run("Validate missing dateTime",
 		testPpoUndeliveredValidate(`{"transactionId": "abc123xxx", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
-			errors.New("PpoUndelivered missing dateTime")))
+			false))
 	t.Run("Validate missing transaction ID",
 		testPpoUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "caseRef": "0123456789", "productCode": "P_TEST_1"}`,
-			errors.New("PpoUndelivered missing transaction ID")))
+			false))
 
 }
 
-func testPpoUndeliveredValidate(msgJson string, expectedErr error) func(*testing.T) {
+func testPpoUndeliveredValidate(msgJson string, valid bool) func(*testing.T) {
 	return func(t *testing.T) {
 		ppoUndelivered := PpoUndelivered{}
 		if err := json.Unmarshal([]byte(msgJson), &ppoUndelivered); err != nil {
 			t.Error(err)
 			return
 		}
-		if err := ppoUndelivered.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
-			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		if err := ppoUndelivered.Validate(); !valid && err == nil || valid && err != nil {
+			t.Errorf("Got err: %s", err)
 		}
 	}
 }

--- a/models/pubSubMessage.go
+++ b/models/pubSubMessage.go
@@ -2,5 +2,5 @@ package models
 
 type PubSubMessage interface {
 	GetTransactionId() string
-	Validate() bool
+	Validate() error
 }

--- a/models/pubSubMessage.go
+++ b/models/pubSubMessage.go
@@ -2,4 +2,5 @@ package models
 
 type PubSubMessage interface {
 	GetTransactionId() string
+	Validate() bool
 }

--- a/models/qmUndelivered.go
+++ b/models/qmUndelivered.go
@@ -3,9 +3,9 @@ package models
 import "errors"
 
 type QmUndelivered struct {
-	TransactionId   string      `json:"transactionId"`
-	DateTime        HazyUtcTime `json:"dateTime"`
-	QuestionnaireId string      `json:"questionnaireId"`
+	TransactionId   string       `json:"transactionId"`
+	DateTime        *HazyUtcTime `json:"dateTime"`
+	QuestionnaireId string       `json:"questionnaireId"`
 }
 
 func (q QmUndelivered) GetTransactionId() string {
@@ -16,7 +16,7 @@ func (q QmUndelivered) Validate() error {
 	if q.GetTransactionId() == "" {
 		return errors.New("QmUndelivered missing transaction ID")
 	}
-	if q.DateTime.IsZero() {
+	if q.DateTime == nil {
 		return errors.New("QmUndelivered missing dateTime")
 	}
 	if q.QuestionnaireId == "" {

--- a/models/qmUndelivered.go
+++ b/models/qmUndelivered.go
@@ -1,11 +1,13 @@
 package models
 
-import "errors"
+import (
+	"github.com/ONSdigital/census-rm-pubsub-adapter/validate"
+)
 
 type QmUndelivered struct {
-	TransactionId   string       `json:"transactionId"`
-	DateTime        *HazyUtcTime `json:"dateTime"`
-	QuestionnaireId string       `json:"questionnaireId"`
+	TransactionId   string       `json:"transactionId" validate:"required"`
+	DateTime        *HazyUtcTime `json:"dateTime" validate:"required"`
+	QuestionnaireId string       `json:"questionnaireId" validate:"required"`
 }
 
 func (q QmUndelivered) GetTransactionId() string {
@@ -13,14 +15,5 @@ func (q QmUndelivered) GetTransactionId() string {
 }
 
 func (q QmUndelivered) Validate() error {
-	if q.GetTransactionId() == "" {
-		return errors.New("QmUndelivered missing transaction ID")
-	}
-	if q.DateTime == nil {
-		return errors.New("QmUndelivered missing dateTime")
-	}
-	if q.QuestionnaireId == "" {
-		return errors.New("QmUndelivered missing questionnaire ID")
-	}
-	return nil
+	return validate.Validate.Struct(q)
 }

--- a/models/qmUndelivered.go
+++ b/models/qmUndelivered.go
@@ -1,5 +1,7 @@
 package models
 
+import "errors"
+
 type QmUndelivered struct {
 	TransactionId   string      `json:"transactionId"`
 	DateTime        HazyUtcTime `json:"dateTime"`
@@ -10,6 +12,15 @@ func (q QmUndelivered) GetTransactionId() string {
 	return q.TransactionId
 }
 
-func (q QmUndelivered) Validate() bool {
-	return q.GetTransactionId() != ""
+func (q QmUndelivered) Validate() error {
+	if q.GetTransactionId() == "" {
+		return errors.New("QmUndelivered missing transaction ID")
+	}
+	if q.DateTime.IsZero() {
+		return errors.New("QmUndelivered missing dateTime")
+	}
+	if q.QuestionnaireId == "" {
+		return errors.New("QmUndelivered missing questionnaire ID")
+	}
+	return nil
 }

--- a/models/qmUndelivered.go
+++ b/models/qmUndelivered.go
@@ -9,3 +9,7 @@ type QmUndelivered struct {
 func (q QmUndelivered) GetTransactionId() string {
 	return q.TransactionId
 }
+
+func (q QmUndelivered) Validate() bool {
+	return q.GetTransactionId() != ""
+}

--- a/models/qmUndelivered_test.go
+++ b/models/qmUndelivered_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 )
 
@@ -10,28 +9,28 @@ func TestQmUndelivered_Validate(t *testing.T) {
 
 	t.Run("Validate good QmUndelivered",
 		testQmUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
-			nil))
+			true))
 	t.Run("Validate missing questionnaire ID",
 		testQmUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx"}`,
-			errors.New("QmUndelivered missing questionnaire ID")))
+			false))
 	t.Run("Validate missing time created",
 		testQmUndeliveredValidate(`{"transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
-			errors.New("QmUndelivered missing dateTime")))
+			false))
 	t.Run("Validate missing transaction ID",
 		testQmUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "questionnaireId": "01213213213"}`,
-			errors.New("QmUndelivered missing transaction ID")))
+			false))
 
 }
 
-func testQmUndeliveredValidate(msgJson string, expectedErr error) func(*testing.T) {
+func testQmUndeliveredValidate(msgJson string, valid bool) func(*testing.T) {
 	return func(t *testing.T) {
 		qmUndelivered := QmUndelivered{}
 		if err := json.Unmarshal([]byte(msgJson), &qmUndelivered); err != nil {
 			t.Error(err)
 			return
 		}
-		if err := qmUndelivered.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
-			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		if err := qmUndelivered.Validate(); !valid && err == nil || valid && err != nil {
+			t.Errorf("Got err: %s", err)
 		}
 	}
 }

--- a/models/qmUndelivered_test.go
+++ b/models/qmUndelivered_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestQmUndelivered_Validate(t *testing.T) {
+
+	t.Run("Validate good QmUndelivered",
+		testQmUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
+			nil))
+	t.Run("Validate missing questionnaire ID",
+		testQmUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "transactionId": "abc123xxx"}`,
+			errors.New("QmUndelivered missing questionnaire ID")))
+	t.Run("Validate missing time created",
+		testQmUndeliveredValidate(`{"transactionId": "abc123xxx", "questionnaireId": "01213213213"}`,
+			errors.New("QmUndelivered missing dateTime")))
+	t.Run("Validate missing transaction ID",
+		testQmUndeliveredValidate(`{"dateTime": "2008-08-24T00:00:00", "questionnaireId": "01213213213"}`,
+			errors.New("QmUndelivered missing transaction ID")))
+
+}
+
+func testQmUndeliveredValidate(msgJson string, expectedErr error) func(*testing.T) {
+	return func(t *testing.T) {
+		qmUndelivered := QmUndelivered{}
+		if err := json.Unmarshal([]byte(msgJson), &qmUndelivered); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := qmUndelivered.Validate(); expectedErr != nil && err == nil || (err != nil && expectedErr != nil) && err.Error() != expectedErr.Error() {
+			t.Errorf("Expected err: %s, got: %s", expectedErr, err)
+		}
+	}
+}

--- a/models/rmResponse.go
+++ b/models/rmResponse.go
@@ -14,11 +14,11 @@ type RmPayload struct {
 }
 
 type RmEvent struct {
-	Type          string    `json:"type"`
-	Source        string    `json:"source"`
-	Channel       string    `json:"channel"`
-	DateTime      time.Time `json:"dateTime"`
-	TransactionID string    `json:"transactionId"`
+	Type          string     `json:"type"`
+	Source        string     `json:"source"`
+	Channel       string     `json:"channel"`
+	DateTime      *time.Time `json:"dateTime"`
+	TransactionID string     `json:"transactionId"`
 }
 
 type RmMessage struct {

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -18,8 +18,8 @@ func unmarshalEqReceipt(data []byte) (models.PubSubMessage, error) {
 	if err := json.Unmarshal(data, &eqReceipt); err != nil {
 		return nil, err
 	}
-	if ok := eqReceipt.Validate(); !ok {
-		return nil, errors.New("message is not valid")
+	if err := eqReceipt.Validate(); err != nil {
+		return nil, err
 	}
 
 	return eqReceipt, nil

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -15,10 +15,13 @@ func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration,
 
 func unmarshalEqReceipt(data []byte) (models.PubSubMessage, error) {
 	var eqReceipt models.EqReceipt
-	err := json.Unmarshal(data, &eqReceipt)
-	if err != nil {
+	if err := json.Unmarshal(data, &eqReceipt); err != nil {
 		return nil, err
 	}
+	if ok := eqReceipt.Validate(); !ok {
+		return nil, errors.New("message is not valid")
+	}
+
 	return eqReceipt, nil
 }
 

--- a/processor/eqReceiptProcessor_test.go
+++ b/processor/eqReceiptProcessor_test.go
@@ -10,7 +10,7 @@ import (
 func TestConvertEqReceiptToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
 	eqReceiptMessage := models.EqReceipt{
-		TimeCreated: timeCreated,
+		TimeCreated: &timeCreated,
 		Metadata: models.EqReceiptMetadata{
 			TransactionId:   "abc123xxx",
 			QuestionnaireId: "01213213213",
@@ -22,7 +22,7 @@ func TestConvertEqReceiptToRmMessage(t *testing.T) {
 			Type:          "RESPONSE_RECEIVED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "EQ",
-			DateTime:      timeCreated,
+			DateTime:      &timeCreated,
 			TransactionID: "abc123xxx",
 		},
 		Payload: models.RmPayload{

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -15,9 +15,11 @@ func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configura
 
 func unmarshalOfflineReceipt(data []byte) (models.PubSubMessage, error) {
 	var offlineReceipt models.OfflineReceipt
-	err := json.Unmarshal(data, &offlineReceipt)
-	if err != nil {
+	if err := json.Unmarshal(data, &offlineReceipt); err != nil {
 		return nil, err
+	}
+	if ok := offlineReceipt.Validate(); !ok {
+		return nil, errors.New("message is not valid")
 	}
 	return offlineReceipt, nil
 }

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -18,8 +18,8 @@ func unmarshalOfflineReceipt(data []byte) (models.PubSubMessage, error) {
 	if err := json.Unmarshal(data, &offlineReceipt); err != nil {
 		return nil, err
 	}
-	if ok := offlineReceipt.Validate(); !ok {
-		return nil, errors.New("message is not valid")
+	if err := offlineReceipt.Validate(); err != nil {
+		return nil, err
 	}
 	return offlineReceipt, nil
 }

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -34,7 +34,7 @@ func convertOfflineReceiptToRmMessage(receipt models.PubSubMessage) (*models.RmM
 			Type:          "RESPONSE_RECEIVED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       offlineReceipt.Channel,
-			DateTime:      offlineReceipt.TimeCreated.Time,
+			DateTime:      &offlineReceipt.TimeCreated.Time,
 			TransactionID: offlineReceipt.TransactionId,
 		},
 		Payload: models.RmPayload{

--- a/processor/offlineReceiptProcessor_test.go
+++ b/processor/offlineReceiptProcessor_test.go
@@ -11,7 +11,7 @@ func TestConvertOfflineReceiptToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
 	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
 	offlineReceiptMessage := models.OfflineReceipt{
-		TimeCreated:     hazyTimeCreated,
+		TimeCreated:     &hazyTimeCreated,
 		TransactionId:   "abc123xxx",
 		QuestionnaireId: "01213213213",
 		Unreceipt:       false,
@@ -23,7 +23,7 @@ func TestConvertOfflineReceiptToRmMessage(t *testing.T) {
 			Type:          "RESPONSE_RECEIVED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "test",
-			DateTime:      timeCreated,
+			DateTime:      &timeCreated,
 			TransactionID: "abc123xxx",
 		},
 		Payload: models.RmPayload{

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -18,6 +18,9 @@ func unmarshalPpoUndelivered(data []byte) (models.PubSubMessage, error) {
 	if err := json.Unmarshal(data, &ppoUndelivered); err != nil {
 		return nil, err
 	}
+	if ok := ppoUndelivered.Validate(); !ok {
+		return nil, errors.New("message is not valid")
+	}
 	return ppoUndelivered, nil
 }
 

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -35,7 +35,7 @@ func convertPpoUndeliveredToRmMessage(message models.PubSubMessage) (*models.RmM
 			Type:          "UNDELIVERED_MAIL_REPORTED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "PPO",
-			DateTime:      ppoUndelivered.DateTime.Time,
+			DateTime:      &ppoUndelivered.DateTime.Time,
 			TransactionID: ppoUndelivered.TransactionId,
 		},
 		Payload: models.RmPayload{

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -18,8 +18,8 @@ func unmarshalPpoUndelivered(data []byte) (models.PubSubMessage, error) {
 	if err := json.Unmarshal(data, &ppoUndelivered); err != nil {
 		return nil, err
 	}
-	if ok := ppoUndelivered.Validate(); !ok {
-		return nil, errors.New("message is not valid")
+	if err := ppoUndelivered.Validate(); err != nil {
+		return nil, err
 	}
 	return ppoUndelivered, nil
 }

--- a/processor/ppoUndeliveredProcessor_test.go
+++ b/processor/ppoUndeliveredProcessor_test.go
@@ -11,7 +11,7 @@ func TestConvertPpoUndeliveredToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
 	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
 	ppoUndeliveredMessage := models.PpoUndelivered{
-		DateTime:      hazyTimeCreated,
+		DateTime:      &hazyTimeCreated,
 		TransactionId: "abc123xxx",
 		CaseRef:       "123456789",
 		ProductCode:   "P_TEST_1",
@@ -22,7 +22,7 @@ func TestConvertPpoUndeliveredToRmMessage(t *testing.T) {
 			Type:          "UNDELIVERED_MAIL_REPORTED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "PPO",
-			DateTime:      timeCreated,
+			DateTime:      &timeCreated,
 			TransactionID: "abc123xxx",
 		},
 		Payload: models.RmPayload{

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -143,9 +143,9 @@ func (p *Processor) quarantineMessageInRabbit(message *pubsub.Message) error {
 		headers[key] = value
 	}
 	err := p.RabbitChannel.Publish(
-		"",
+		"",                     // empty string for the default exchange
 		p.Config.DlqRoutingKey, // routing key (the queue)
-		false,                  // mandatory
+		false,                  // immediate
 		false,                  // immediate
 		amqp.Publishing{
 			ContentType:  "application/json",

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -35,7 +35,7 @@ func convertQmUndeliveredToRmMessage(message models.PubSubMessage) (*models.RmMe
 			Type:          "UNDELIVERED_MAIL_REPORTED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "QM",
-			DateTime:      qmUndelivered.DateTime.Time,
+			DateTime:      &qmUndelivered.DateTime.Time,
 			TransactionID: qmUndelivered.TransactionId,
 		},
 		Payload: models.RmPayload{

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -18,8 +18,8 @@ func unmarshalQmUndelivered(data []byte) (models.PubSubMessage, error) {
 	if err := json.Unmarshal(data, &qmUndelivered); err != nil {
 		return nil, err
 	}
-	if ok := qmUndelivered.Validate(); !ok {
-		return nil, errors.New("message is not valid")
+	if err := qmUndelivered.Validate(); err != nil {
+		return nil, err
 	}
 	return qmUndelivered, nil
 }

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -15,9 +15,11 @@ func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configurat
 
 func unmarshalQmUndelivered(data []byte) (models.PubSubMessage, error) {
 	var qmUndelivered models.QmUndelivered
-	err := json.Unmarshal(data, &qmUndelivered)
-	if err != nil {
+	if err := json.Unmarshal(data, &qmUndelivered); err != nil {
 		return nil, err
+	}
+	if ok := qmUndelivered.Validate(); !ok {
+		return nil, errors.New("message is not valid")
 	}
 	return qmUndelivered, nil
 }

--- a/processor/qmUndeliveredProcessor_test.go
+++ b/processor/qmUndeliveredProcessor_test.go
@@ -11,7 +11,7 @@ func TestConvertQmUndeliveredToRmMessage(t *testing.T) {
 	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
 	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
 	qmUndeliveredMessage := models.QmUndelivered{
-		DateTime:        hazyTimeCreated,
+		DateTime:        &hazyTimeCreated,
 		TransactionId:   "abc123xxx",
 		QuestionnaireId: "01213213213",
 	}
@@ -21,7 +21,7 @@ func TestConvertQmUndeliveredToRmMessage(t *testing.T) {
 			Type:          "UNDELIVERED_MAIL_REPORTED",
 			Source:        "RECEIPT_SERVICE",
 			Channel:       "QM",
-			DateTime:      timeCreated,
+			DateTime:      &timeCreated,
 			TransactionID: "abc123xxx",
 		},
 		Payload: models.RmPayload{

--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -43,6 +43,15 @@
       "arguments": {
         "x-queue-type": "classic"
       }
+    },
+    {
+      "name": "goTestQuarantineQueue",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-queue-type": "classic"
+      }
     }
   ]
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,0 +1,10 @@
+package validate
+
+import "github.com/go-playground/validator/v10"
+
+// use a single instance of Validate, it caches struct info
+var Validate *validator.Validate
+
+func init() {
+	Validate = validator.New()
+}


### PR DESCRIPTION
# Motivation and Context
We need to persist messages that error somewhere so they can be alerted on/dealth with appropriately later.
Also includes a refactor to call the message processor synchronously from the pubsub receiver, as recommended by [their documentation](https://godoc.org/cloud.google.com/go/pubsub#Subscription.Receive) since the receive function handles concurrency itself. As it was, we were funneling that concurrency down into a single processing function creating blockages rather than assuaging them. 

# What has changed
* Add quarantine queue, send messages we can't unmarshal or validate
* Refactor processor function to be called synchronously by pubsub receiver
* Improve contextual logging within the message processors
* Add validation functions to each pubsub message type
* Modify docker file so depenencies can be a cached layer

# How to test?
Run the service against it's docker compose dependencies, try posting and invalid message in. It should now log an error and send it to the quarantine queue.
Run the acceptance tests with pubsub adapter running instead of pubsubsvc.

# Links
https://trello.com/c/y4rKo0fl/906-pubsub-adapter-dlq-messages-it-cant-process-8
https://godoc.org/cloud.google.com/go/pubsub#Subscription.Receive
