### PR TITLE
Wrap start up errors with more helpful messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,28 +66,28 @@ func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan cha
 	// Start EQ receipt processing
 	eqReceiptProcessor, err := processor.NewEqReceiptProcessor(ctx, cfg, errChan)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Error starting eQ receipt processor")
 	}
 	processors = append(processors, eqReceiptProcessor)
 
 	// Start offline receipt processing
 	offlineReceiptProcessor, err := processor.NewOfflineReceiptProcessor(ctx, cfg, errChan)
 	if err != nil {
-		return processors, err
+		return processors, errors.Wrap(err, "Error starting offline receipt processor")
 	}
 	processors = append(processors, offlineReceiptProcessor)
 
 	// Start PPO undelivered processing
 	ppoUndeliveredProcessor, err := processor.NewPpoUndeliveredProcessor(ctx, cfg, errChan)
 	if err != nil {
-		return processors, err
+		return processors, errors.Wrap(err, "Error starting PPO undelivered processor")
 	}
 	processors = append(processors, ppoUndeliveredProcessor)
 
 	// Start QM undelivered processing
 	qmUndeliveredProcessor, err := processor.NewQmUndeliveredProcessor(ctx, cfg, errChan)
 	if err != nil {
-		return processors, err
+		return processors, errors.Wrap(err, "Error starting QM undelivered processor")
 	}
 	processors = append(processors, qmUndeliveredProcessor)
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/config"
 	"github.com/ONSdigital/census-rm-pubsub-adapter/logger"
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
+	"github.com/pkg/errors"
 	"github.com/streadway/amqp"
 	"go.uber.org/zap"
 )
@@ -47,7 +48,7 @@ func NewProcessor(ctx context.Context,
 	// Set up rabbit connection
 	p.RabbitConn, err = amqp.Dial(appConfig.RabbitConnectionString)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error connecting to rabbit")
 	}
 
 	p.RabbitChannel, err = p.RabbitConn.Channel()
@@ -58,7 +59,7 @@ func NewProcessor(ctx context.Context,
 	// Setup PubSub connection
 	p.PubSubClient, err = pubsub.NewClient(ctx, pubSubProject)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error settings up PubSub client")
 	}
 
 	// Setup subscription


### PR DESCRIPTION
# Motivation and Context
We were seeing start up errors with unhelpful, unspecific messages.

# What has changed
* Wrap start up errors with more helpful messages

# How to test?
Start up the service misconfigured in a variety of ways, the error reporting should now be more helpful.

# Links
https://trello.com/c/nycuotpH/959-pubsub-adatper-improve-error-reporting
