### PR TITLE
Handle Fulfilment Confirmed pubsub messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ QM_UNDELIVERED_SUBSCRIPTION_PROJECT=qm-undelivered-project
 PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
 RECEIPT_ROUTING_KEY=goTestReceiptQueue
 UNDELIVERED_ROUTING_KEY=goTestUndeliveredQueue
+FULFILMENT_CONFIRMED_PROJECT=fulfilment-project
 ```
 
 ### Config to run locally against docker dev
@@ -52,6 +53,7 @@ EQ_RECEIPT_PROJECT=project
 OFFLINE_RECEIPT_PROJECT=offline-project
 QM_UNDELIVERED_SUBSCRIPTION_PROJECT=qm-undelivered-project
 PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
+FULFILMENT_CONFIRMED_PROJECT=fulfilment-project
 ```
 
 ## Running the tests

--- a/config/config.go
+++ b/config/config.go
@@ -21,20 +21,24 @@ type Configuration struct {
 	ReceiptRoutingKey      string `envconfig:"RECEIPT_ROUTING_KEY"  default:"event.response.receipt"`
 	UndeliveredRoutingKey  string `envconfig:"UNDELIVERED_ROUTING_KEY"  default:"event.fulfilment.undelivered"`
 	DlqRoutingKey          string `envconfig:"DLQ_ROUTING_KEY"  default:"pubsub.quarantine"`
+	FulfilmentRoutingKey   string `envconfig:"FULFILMENT_ROUTING_KEY"  default:"event.fulfilment.confirmation"`
 
 	// PubSub
-	EqReceiptProject           string `envconfig:"EQ_RECEIPT_PROJECT" required:"true"`
-	EqReceiptSubscription      string `envconfig:"EQ_RECEIPT_SUBSCRIPTION" default:"rm-receipt-subscription"`
-	EqReceiptTopic             string `envconfig:"EQ_RECEIPT_TOPIC" default:"eq-submission-topic"`
-	OfflineReceiptProject      string `envconfig:"OFFLINE_RECEIPT_PROJECT" required:"true"`
-	OfflineReceiptSubscription string `envconfig:"OFFLINE_RECEIPT_SUBSCRIPTION" default:"rm-offline-receipt-subscription"`
-	OfflineReceiptTopic        string `envconfig:"OFFLINE_RECEIPT_TOPIC" default:"offline-receipt-topic"`
-	PpoUndeliveredProject      string `envconfig:"PPO_UNDELIVERED_SUBSCRIPTION_PROJECT" required:"true"`
-	PpoUndeliveredSubscription string `envconfig:"PPO_UNDELIVERED_SUBSCRIPTION" default:"rm-ppo-undelivered-subscription"`
-	PpoUndeliveredTopic        string `envconfig:"PPO_UNDELIVERED_TOPIC" default:"ppo-undelivered-topic"`
-	QmUndeliveredProject       string `envconfig:"QM_UNDELIVERED_SUBSCRIPTION_PROJECT" required:"true"`
-	QmUndeliveredSubscription  string `envconfig:"QM_UNDELIVERED_SUBSCRIPTION" default:"rm-qm-undelivered-subscription"`
-	QmUndeliveredTopic         string `envconfig:"QM_UNDELIVERED_TOPIC" default:"qm-undelivered-topic"`
+	EqReceiptProject                string `envconfig:"EQ_RECEIPT_PROJECT" required:"true"`
+	EqReceiptSubscription           string `envconfig:"EQ_RECEIPT_SUBSCRIPTION" default:"rm-receipt-subscription"`
+	EqReceiptTopic                  string `envconfig:"EQ_RECEIPT_TOPIC" default:"eq-submission-topic"`
+	OfflineReceiptProject           string `envconfig:"OFFLINE_RECEIPT_PROJECT" required:"true"`
+	OfflineReceiptSubscription      string `envconfig:"OFFLINE_RECEIPT_SUBSCRIPTION" default:"rm-offline-receipt-subscription"`
+	OfflineReceiptTopic             string `envconfig:"OFFLINE_RECEIPT_TOPIC" default:"offline-receipt-topic"`
+	PpoUndeliveredProject           string `envconfig:"PPO_UNDELIVERED_SUBSCRIPTION_PROJECT" required:"true"`
+	PpoUndeliveredSubscription      string `envconfig:"PPO_UNDELIVERED_SUBSCRIPTION" default:"rm-ppo-undelivered-subscription"`
+	PpoUndeliveredTopic             string `envconfig:"PPO_UNDELIVERED_TOPIC" default:"ppo-undelivered-topic"`
+	QmUndeliveredProject            string `envconfig:"QM_UNDELIVERED_SUBSCRIPTION_PROJECT" required:"true"`
+	QmUndeliveredSubscription       string `envconfig:"QM_UNDELIVERED_SUBSCRIPTION" default:"rm-qm-undelivered-subscription"`
+	QmUndeliveredTopic              string `envconfig:"QM_UNDELIVERED_TOPIC" default:"qm-undelivered-topic"`
+	FulfilmentConfirmedProject      string `envconfig:"FULFILMENT_CONFIRMED_PROJECT" required:"true"`
+	FulfilmentConfirmedSubscription string `envconfig:"FULFILMENT_CONFIRMED_SUBSCRIPTION" default:"fulfilment-subscription"`
+	FulfilmentConfirmedTopic        string `envconfig:"FULFILMENT_CONFIRMED_TOPIC" default:"fulfilment-topic"`
 }
 
 var cfg *Configuration

--- a/main.go
+++ b/main.go
@@ -91,6 +91,13 @@ func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan cha
 	}
 	processors = append(processors, qmUndeliveredProcessor)
 
+	// Start fulfilment confirmed processing
+	fulfilmentConfirmedProcessor, err := processor.NewFulfilmentConfirmedProcessor(ctx, cfg, errChan)
+	if err != nil {
+		return processors, errors.Wrap(err, "Error starting fulfilment confirmed processor")
+	}
+	processors = append(processors, fulfilmentConfirmedProcessor)
+
 	return processors, nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -138,7 +138,7 @@ func TestStartProcessors(t *testing.T) {
 	}
 
 	if len(processors) != 5 {
-		t.Errorf("StartProcessors should return 4 processors, actually returned %d", len(processors))
+		t.Errorf("StartProcessors should return 5 processors, actually returned %d", len(processors))
 	}
 }
 

--- a/models/fulfilmentConfirmed.go
+++ b/models/fulfilmentConfirmed.go
@@ -27,7 +27,7 @@ func (o FulfilmentConfirmed) Validate() error {
 			err = errors.New(fmt.Sprintf("Missing questionnaire ID in QM message: %T, tx_id: %q", o, o.GetTransactionId()))
 		} else if o.Channel == "PPO" && len(o.CaseRef) == 0 {
 			err = errors.New(fmt.Sprintf("Missing case ref in PPO message: %T, tx_id: %q", o, o.GetTransactionId()))
-		} else {
+		} else if o.Channel != "QM" && o.Channel != "PPO" {
 			err = errors.New(fmt.Sprintf("Unexpected channel: %T, tx_id: %q", o, o.GetTransactionId()))
 		}
 	}

--- a/models/fulfilmentConfirmed.go
+++ b/models/fulfilmentConfirmed.go
@@ -23,14 +23,10 @@ func (o FulfilmentConfirmed) Validate() error {
 	err := validate.Validate.Struct(o)
 
 	if err == nil {
-		if o.Channel == "QM" {
-			if len(o.QuestionnaireId) == 0 {
-				err = errors.New(fmt.Sprintf("Missing questionnaire ID in QM message: %T, tx_id: %q", o, o.GetTransactionId()))
-			}
-		} else if o.Channel == "PPO" {
-			if len(o.CaseRef) == 0 {
-				err = errors.New(fmt.Sprintf("Missing case ref in PPO message: %T, tx_id: %q", o, o.GetTransactionId()))
-			}
+		if o.Channel == "QM" && len(o.QuestionnaireId) == 0 {
+			err = errors.New(fmt.Sprintf("Missing questionnaire ID in QM message: %T, tx_id: %q", o, o.GetTransactionId()))
+		} else if o.Channel == "PPO" && len(o.CaseRef) == 0 {
+			err = errors.New(fmt.Sprintf("Missing case ref in PPO message: %T, tx_id: %q", o, o.GetTransactionId()))
 		} else {
 			err = errors.New(fmt.Sprintf("Unexpected channel: %T, tx_id: %q", o, o.GetTransactionId()))
 		}

--- a/models/fulfilmentConfirmed.go
+++ b/models/fulfilmentConfirmed.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/validate"
+)
+
+type FulfilmentConfirmed struct {
+	TimeCreated     *HazyUtcTime `json:"dateTime" validate:"required"`
+	TransactionId   string       `json:"transactionId" validate:"required"`
+	ProductCode     string       `json:"productCode" validate:"required"`
+	Channel         string       `json:"channel" validate:"required"`
+	QuestionnaireId string       `json:"questionnaireId"`
+	CaseRef         string       `json:"caseRef"`
+}
+
+func (o FulfilmentConfirmed) GetTransactionId() string {
+	return o.TransactionId
+}
+
+func (o FulfilmentConfirmed) Validate() error {
+	err := validate.Validate.Struct(o)
+
+	if err == nil {
+		if o.Channel == "QM" {
+			if len(o.QuestionnaireId) == 0 {
+				err = errors.New(fmt.Sprintf("Missing questionnaire ID in QM message: %T, tx_id: %q", o, o.GetTransactionId()))
+			}
+		} else if o.Channel == "PPO" {
+			if len(o.CaseRef) == 0 {
+				err = errors.New(fmt.Sprintf("Missing case ref in PPO message: %T, tx_id: %q", o, o.GetTransactionId()))
+			}
+		} else {
+			err = errors.New(fmt.Sprintf("Unexpected channel: %T, tx_id: %q", o, o.GetTransactionId()))
+		}
+	}
+
+	return err
+}

--- a/models/fulfilmentConfirmed_test.go
+++ b/models/fulfilmentConfirmed_test.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFulfilmentConfirmed_Validate_Validate(t *testing.T) {
+
+	t.Run("Validate good QM FulfilmentConfirmed",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","questionnaireId":"1100000000112","productCode":"P_OR_H1","channel":"QM","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			true))
+	t.Run("Validate good PPO FulfilmentConfirmed",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","caseRef":"12345678","productCode":"P_OR_H1","channel":"PPO","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			true))
+	t.Run("Validate missing product code",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","questionnaireId":"1100000000112","channel":"QM","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			false))
+	t.Run("Validate missing time created",
+		testFulfilmentConfirmedValidate(`{"questionnaireId":"1100000000112","productCode":"P_OR_H1","channel":"QM","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			false))
+	t.Run("Validate missing transaction ID",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","questionnaireId":"1100000000112","productCode":"P_OR_H1","channel":"QM","type":"FULFILMENT_CONFIRMED"}`,
+			false))
+	t.Run("Validate missing channel",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","questionnaireId":"1100000000112","productCode":"P_OR_H1","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			false))
+	t.Run("Validate missing questionnaire ID",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","productCode":"P_OR_H1","channel":"QM","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			false))
+	t.Run("Validate missing case ref",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","productCode":"P_OR_H1","channel":"PPO","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			false))
+	t.Run("Validate dodgy channel",
+		testFulfilmentConfirmedValidate(`{"dateTime":"2019-08-03T14:30:01","questionnaireId":"1100000000112","productCode":"P_OR_H1","channel":"NOODLEBANANA","type":"FULFILMENT_CONFIRMED","transactionId":"92971ad5-c534-48af-a8b3-92484b14ceef"}`,
+			false))
+}
+
+func testFulfilmentConfirmedValidate(msgJson string, valid bool) func(*testing.T) {
+	return func(t *testing.T) {
+		fulfilmentConfirmed := FulfilmentConfirmed{}
+		if err := json.Unmarshal([]byte(msgJson), &fulfilmentConfirmed); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := fulfilmentConfirmed.Validate(); !valid && err == nil || valid && err != nil {
+			t.Errorf("Got err: %s", err)
+		}
+	}
+}

--- a/processor/fulfilmentConfirmedProcessor.go
+++ b/processor/fulfilmentConfirmedProcessor.go
@@ -1,0 +1,59 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/config"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
+	"github.com/pkg/errors"
+)
+
+func NewFulfilmentConfirmedProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+	return NewProcessor(ctx, appConfig, appConfig.FulfilmentConfirmedProject, appConfig.FulfilmentConfirmedSubscription, appConfig.FulfilmentRoutingKey, convertFulfilmentConfirmedToRmMessage, unmarshalFulfilmentConfirmed, errChan)
+}
+
+func unmarshalFulfilmentConfirmed(data []byte) (models.PubSubMessage, error) {
+	var fulfilmentConfirmed models.FulfilmentConfirmed
+	if err := json.Unmarshal(data, &fulfilmentConfirmed); err != nil {
+		return nil, err
+	}
+	if err := fulfilmentConfirmed.Validate(); err != nil {
+		return nil, err
+	}
+	return fulfilmentConfirmed, nil
+}
+
+func convertFulfilmentConfirmedToRmMessage(confirmation models.PubSubMessage) (*models.RmMessage, error) {
+	fulfilmentConfirmed, ok := confirmation.(models.FulfilmentConfirmed)
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("Wrong message model given to convertFulfilmentConfirmedToRmMessage: %T, only accepts FulfilmentConfirmed, tx_id: %q", confirmation, confirmation.GetTransactionId()))
+	}
+
+	var payload models.FulfilmentInformation
+	if fulfilmentConfirmed.Channel == "QM" {
+		payload = models.FulfilmentInformation{
+			QuestionnaireId: fulfilmentConfirmed.QuestionnaireId,
+			FulfilmentCode:  fulfilmentConfirmed.ProductCode,
+		}
+	} else {
+		// This must be a PPO message, by a process of elimination
+		payload = models.FulfilmentInformation{
+			CaseRef:        fulfilmentConfirmed.CaseRef,
+			FulfilmentCode: fulfilmentConfirmed.ProductCode,
+		}
+	}
+
+	return &models.RmMessage{
+		Event: models.RmEvent{
+			Type:          "FULFILMENT_CONFIRMED",
+			Source:        "RECEIPT_SERVICE",
+			Channel:       fulfilmentConfirmed.Channel,
+			DateTime:      &fulfilmentConfirmed.TimeCreated.Time,
+			TransactionID: fulfilmentConfirmed.TransactionId,
+		},
+		Payload: models.RmPayload{
+			FulfilmentInformation: &payload,
+		},
+	}, nil
+}

--- a/processor/fulfilmentConfirmedProcessor_test.go
+++ b/processor/fulfilmentConfirmedProcessor_test.go
@@ -1,0 +1,80 @@
+package processor
+
+import (
+	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestConvertQMFulfilmentConfirmedToRmMessage(t *testing.T) {
+	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
+	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
+	offlineReceiptMessage := models.FulfilmentConfirmed{
+		TimeCreated:     &hazyTimeCreated,
+		TransactionId:   "abc123xxx",
+		QuestionnaireId: "01213213213",
+		Channel:         "QM",
+		ProductCode:     "ABC_XYZ_123",
+	}
+
+	expectedRabbitMessage := models.RmMessage{
+		Event: models.RmEvent{
+			Type:          "FULFILMENT_CONFIRMED",
+			Source:        "RECEIPT_SERVICE",
+			Channel:       "QM",
+			DateTime:      &timeCreated,
+			TransactionID: "abc123xxx",
+		},
+		Payload: models.RmPayload{
+			FulfilmentInformation: &models.FulfilmentInformation{
+				QuestionnaireId: "01213213213",
+				FulfilmentCode:  "ABC_XYZ_123",
+			},
+		}}
+
+	rabbitMessage, err := convertFulfilmentConfirmedToRmMessage(offlineReceiptMessage)
+	if err != nil {
+		t.Errorf("failed: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedRabbitMessage, *rabbitMessage) {
+		t.Errorf("Incorrect Rabbit message structure \nexpected:%+v \nactual:%+v", expectedRabbitMessage, rabbitMessage)
+	}
+}
+
+func TestConvertPPOFulfilmentConfirmedToRmMessage(t *testing.T) {
+	timeCreated, _ := time.Parse("2006-07-08T03:04:05Z", "2008-08-24T00:00:00Z")
+	hazyTimeCreated := models.HazyUtcTime{Time: timeCreated}
+	offlineReceiptMessage := models.FulfilmentConfirmed{
+		TimeCreated:   &hazyTimeCreated,
+		TransactionId: "abc123xxx",
+		CaseRef:       "666123999",
+		Channel:       "PPO",
+		ProductCode:   "ABC_XYZ_123",
+	}
+
+	expectedRabbitMessage := models.RmMessage{
+		Event: models.RmEvent{
+			Type:          "FULFILMENT_CONFIRMED",
+			Source:        "RECEIPT_SERVICE",
+			Channel:       "PPO",
+			DateTime:      &timeCreated,
+			TransactionID: "abc123xxx",
+		},
+		Payload: models.RmPayload{
+			FulfilmentInformation: &models.FulfilmentInformation{
+				CaseRef:        "666123999",
+				FulfilmentCode: "ABC_XYZ_123",
+			},
+		}}
+
+	rabbitMessage, err := convertFulfilmentConfirmedToRmMessage(offlineReceiptMessage)
+	if err != nil {
+		t.Errorf("failed: %s", err)
+	}
+
+	if !reflect.DeepEqual(expectedRabbitMessage, *rabbitMessage) {
+		t.Errorf("Incorrect Rabbit message structure \nexpected:%+v \nactual:%+v", expectedRabbitMessage, rabbitMessage)
+	}
+}

--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -85,6 +85,11 @@ spec:
                 configMapKeyRef:
                   name: project-config
                   key: project-name
+            - name: FULFILMENT_CONFIRMED_PROJECT
+              valueFrom:
+                configMapKeyRef:
+                  name: project-config
+                  key: project-name
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/gcp-credentials/service-account-key.json"
             - name: RABBIT_HOST

--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -45,6 +45,15 @@
       }
     },
     {
+      "name": "goTestFulfilmentConfirmedQueue",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {
+        "x-queue-type": "classic"
+      }
+    },
+    {
       "name": "goTestQuarantineQueue",
       "vhost": "/",
       "durable": true,

--- a/setup_dependencies.sh
+++ b/setup_dependencies.sh
@@ -27,12 +27,14 @@ wait_for_curl_success "http://localhost:8539/v1/projects/project/topics/eq-submi
 wait_for_curl_success "http://localhost:8539/v1/projects/offline-project/topics/offline-receipt-topic" "PUT" "pubsub_emulator topic"
 wait_for_curl_success "http://localhost:8539/v1/projects/ppo-undelivered-project/topics/ppo-undelivered-mail-topic" "PUT" "pubsub_emulator topic"
 wait_for_curl_success "http://localhost:8539/v1/projects/qm-undelivered-project/topics/qm-undelivered-mail-topic" "PUT" "pubsub_emulator topic"
+wait_for_curl_success "http://localhost:8539/v1/projects/fulfilment-confirmed-project/topics/fulfilment-topic" "PUT" "pubsub_emulator topic"
 
 echo "Setting up subscriptions to topics..."
 curl -X PUT http://localhost:8539/v1/projects/project/subscriptions/rm-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/project/topics/eq-submission-topic"}'
 curl -X PUT http://localhost:8539/v1/projects/offline-project/subscriptions/rm-offline-receipt-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/offline-project/topics/offline-receipt-topic"}'
 curl -X PUT http://localhost:8539/v1/projects/ppo-undelivered-project/subscriptions/rm-ppo-undelivered-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/ppo-undelivered-project/topics/ppo-undelivered-mail-topic"}'
 curl -X PUT http://localhost:8539/v1/projects/qm-undelivered-project/subscriptions/rm-qm-undelivered-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/qm-undelivered-project/topics/qm-undelivered-mail-topic"}'
+curl -X PUT http://localhost:8539/v1/projects/fulfilment-confirmed-project/subscriptions/fulfilment-subscription -H 'Content-Type: application/json' -d '{"topic": "projects/fulfilment-confirmed-project/topics/fulfilment-topic"}'
 
 wait_for_curl_success "http://guest:guest@localhost:17672/api/aliveness-test/%2F" "GET" "rabbitmq"
 


### PR DESCRIPTION
# Motivation and Context
We need to process fulfilment confirmations from the print suppliers so that we know when things have been printed.

# What has changed
Added a fulfilment confirmed processor.

# How to test?
Use the new docker dev to spin up the new topic/subscriptions, then plonk some messages into the pubsub topics and retire to a safe distance.

# Links
Trello: https://trello.com/c/QShkkGg6