### PR TITLE
Add handler for rabbit connection and channel closes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ RECEIPT_ROUTING_KEY=goTestReceiptQueue
 UNDELIVERED_ROUTING_KEY=goTestUndeliveredQueue
 FULFILMENT_CONFIRMED_PROJECT=fulfilment-project
 QUARANTINE_MESSAGE_URL=http://httpbin.org/post
+RABBIT_EXCHANGE=
 ```
+
+NB: `RABBIT_EXCHANGE` is intentionally an empty string to use the rabbit default exchange
 
 ### Config to run locally against docker dev
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       - OFFLINE_RECEIPT_PROJECT=offline-project
       - QM_UNDELIVERED_SUBSCRIPTION_PROJECT=qm-undelivered-project
       - PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
+      - FULFILMENT_CONFIRMED_PROJECT=fulfilment-confirmed-project
+      - QUARANTINE_MESSAGE_URL=http://httpbin.org/post
       - LOG_LEVEL=INFO
     restart: on-failure
     healthcheck:

--- a/main_test.go
+++ b/main_test.go
@@ -252,6 +252,9 @@ func TestRabbitReconnect(t *testing.T) {
 	}
 
 	// Break the channel by publishing a mandatory message that can't be routed
+	// NB: This is not a typical scenario this feature is designed around as the app or rabbit would have to be
+	// mis-configured for this to occur, and the channel closing is only an undesirable side effect.
+	// It is, however, the only viable way of inducing a channel close that I could think of using to exercise this code.
 	if err := processor.RabbitChannel.Publish(
 		"this_exchange_should_not_exist",
 		cfg.ReceiptRoutingKey,

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -49,14 +49,8 @@ func NewProcessor(ctx context.Context,
 	p.ErrChan = errChan
 	p.Logger = logger.Logger.With("subscription", pubSubSubscription)
 
-	// Set up rabbit connection
-	p.RabbitConn, err = amqp.Dial(appConfig.RabbitConnectionString)
-	if err != nil {
-		return nil, errors.Wrap(err, "error connecting to rabbit")
-	}
-
-	p.RabbitChannel, err = p.RabbitConn.Channel()
-	if err != nil {
+	// Setup Rabbit
+	if err := p.initRabbit(); err != nil {
 		return nil, err
 	}
 
@@ -74,6 +68,50 @@ func NewProcessor(ctx context.Context,
 	go p.Consume(ctx)
 
 	return p, nil
+}
+
+func (p *Processor) initRabbit() error {
+	if err := p.initRabbitConnection(); err != nil {
+		return err
+	}
+
+	if err := p.initRabbitChannel(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Processor) initRabbitConnection() error {
+	var err error
+
+	// Open the rabbit connection
+	p.RabbitConn, err = amqp.Dial(p.Config.RabbitConnectionString)
+	if err != nil {
+		return errors.Wrap(err, "error connecting to rabbit")
+	}
+	return nil
+}
+
+func (p *Processor) initRabbitChannel() error {
+	var err error
+
+	// Open the rabbit channel
+	p.RabbitChannel, err = p.RabbitConn.Channel()
+	if err != nil {
+		return errors.Wrap(err, "error opening rabbit channel")
+	}
+
+	// Set up handler to attempt to reopen channel on channel close
+	// Listen for errors on the rabbit channel to handle both channel specific and connection wide exceptions
+	channelErrChan := make(chan *amqp.Error)
+	go func() {
+		channelErr := <-channelErrChan
+		p.Logger.Errorw("received rabbit channel error, reconnecting", "error", channelErr)
+		_ = p.initRabbit()
+	}()
+	p.RabbitChannel.NotifyClose(channelErrChan)
+
+	return nil
 }
 
 func (p *Processor) Consume(ctx context.Context) {
@@ -122,7 +160,7 @@ func (p *Processor) publishEventToRabbit(message *models.RmMessage, routingKey s
 		return err
 	}
 
-	err = p.RabbitChannel.Publish(
+	if err := p.RabbitChannel.Publish(
 		exchange,
 		routingKey, // routing key (the queue)
 		false,      // mandatory
@@ -131,8 +169,7 @@ func (p *Processor) publishEventToRabbit(message *models.RmMessage, routingKey s
 			ContentType:  "application/json",
 			Body:         byteMessage,
 			DeliveryMode: 2, // 2 = persistent delivery mode
-		})
-	if err != nil {
+		}); err != nil {
 		return err
 	}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -106,6 +106,8 @@ func (p *Processor) initRabbitChannel() error {
 	channelErrChan := make(chan *amqp.Error)
 	go func() {
 		channelErr := <-channelErrChan
+
+		// TODO handle reconnecting in graceful processor restart rather than a direct call to reinitialize here
 		p.Logger.Errorw("received rabbit channel error, reconnecting", "error", channelErr)
 		_ = p.initRabbit()
 	}()


### PR DESCRIPTION
# Motivation and Context
This PR is to show how the `NotifyClose` handler can be used

# What has changed
* Add rabbit channel notify close handler to reconnect channel

# How to test?
Run the service on this branch, delete one of its rabbit channels in the management UI. The service should now reconnect itself rather than erroring till it restarts

# Links
https://trello.com/c/cub7E1vf/989-spike-robust-rabbit-connection-in-pubsub-adapter-1-day
