### PR TITLE
Persist quarantined messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ EQ_RECEIPT_PROJECT
 OFFLINE_RECEIPT_PROJECT
 QM_UNDELIVERED_SUBSCRIPTION_PROJECT
 PPO_UNDELIVERED_SUBSCRIPTION_PROJECT
+QUARANTINE_MESSAGE_URL
 ```
 
 ### Config to run locally against docker-compose dependencies
@@ -37,6 +38,7 @@ PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
 RECEIPT_ROUTING_KEY=goTestReceiptQueue
 UNDELIVERED_ROUTING_KEY=goTestUndeliveredQueue
 FULFILMENT_CONFIRMED_PROJECT=fulfilment-project
+QUARANTINE_MESSAGE_URL=http://httpbin.org/post
 ```
 
 ### Config to run locally against docker dev
@@ -53,7 +55,8 @@ EQ_RECEIPT_PROJECT=project
 OFFLINE_RECEIPT_PROJECT=offline-project
 QM_UNDELIVERED_SUBSCRIPTION_PROJECT=qm-undelivered-project
 PPO_UNDELIVERED_SUBSCRIPTION_PROJECT=ppo-undelivered-project
-FULFILMENT_CONFIRMED_PROJECT=fulfilment-project
+FULFILMENT_CONFIRMED_PROJECT=fulfilment-confirmed-project
+QUARANTINE_MESSAGE_URL=http://localhost:8666/storeskippedmessage
 ```
 
 ## Running the tests

--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Configuration struct {
-	ReadinessFilePath string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
-	LogLevel          string `envconfig:"LOG_LEVEL" default:"ERROR"`
+	ReadinessFilePath    string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
+	LogLevel             string `envconfig:"LOG_LEVEL" default:"ERROR"`
+	QuarantineMessageUrl string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
 
 	// Rabbit
 	RabbitHost             string `envconfig:"RABBIT_HOST" required:"true"`
@@ -20,7 +21,6 @@ type Configuration struct {
 	EventsExchange         string `envconfig:"RABBIT_EXCHANGE"  default:"events"`
 	ReceiptRoutingKey      string `envconfig:"RECEIPT_ROUTING_KEY"  default:"event.response.receipt"`
 	UndeliveredRoutingKey  string `envconfig:"UNDELIVERED_ROUTING_KEY"  default:"event.fulfilment.undelivered"`
-	DlqRoutingKey          string `envconfig:"DLQ_ROUTING_KEY"  default:"pubsub.quarantine"`
 	FulfilmentRoutingKey   string `envconfig:"FULFILMENT_ROUTING_KEY"  default:"event.fulfilment.confirmation"`
 
 	// PubSub

--- a/main_test.go
+++ b/main_test.go
@@ -7,9 +7,14 @@ package main
 import (
 	"cloud.google.com/go/pubsub"
 	"context"
+	"encoding/json"
 	"errors"
 	"github.com/ONSdigital/census-rm-pubsub-adapter/config"
+	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 	"github.com/streadway/amqp"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"runtime"
 	"testing"
@@ -28,7 +33,6 @@ func TestMain(m *testing.M) {
 		ReceiptRoutingKey:               "goTestReceiptQueue",
 		UndeliveredRoutingKey:           "goTestUndeliveredQueue",
 		FulfilmentRoutingKey:            "goTestFulfilmentConfirmedQueue",
-		DlqRoutingKey:                   "goTestQuarantineQueue",
 		EqReceiptProject:                "project",
 		EqReceiptSubscription:           "rm-receipt-subscription",
 		EqReceiptTopic:                  "eq-submission-topic",
@@ -81,16 +85,92 @@ func TestMessageProcessing(t *testing.T) {
 		cfg.FulfilmentConfirmedTopic, cfg.FulfilmentConfirmedProject, cfg.FulfilmentRoutingKey))
 }
 
-func TestMessageQuarantining(t *testing.T) {
-	t.Run("Test bad non JSON message is quarantined", testMessageProcessing(
-		`bad_message`,
-		`bad_message`,
-		cfg.EqReceiptTopic, cfg.EqReceiptProject, cfg.DlqRoutingKey))
+func TestMessageQuarantiningBadJson(t *testing.T) {
+	testMessageQuarantining("bad_message", "Test bad non JSON message is quarantined", t)
+}
 
-	t.Run("Test bad message missing transaction ID is quarantined", testMessageProcessing(
-		`{"thisMessage": "is_missing_tx_id"}`,
-		`{"thisMessage": "is_missing_tx_id"}`,
-		cfg.EqReceiptTopic, cfg.EqReceiptProject, cfg.DlqRoutingKey))
+func TestMessageQuarantiningMissingTxnId(t *testing.T) {
+	testMessageQuarantining(`{"thisMessage": "is_missing_tx_id"}`, "Test bad message missing transaction ID is quarantined", t)
+}
+
+func testMessageQuarantining(messageToSend string, testDescription string, t *testing.T) {
+	var requests []*http.Request
+	var requestBody []byte
+
+	mockResult := "Success!"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(mockResult))
+		requests = append(requests, r)
+		requestBody, _ = ioutil.ReadAll(r.Body)
+	}))
+	defer srv.Close()
+
+	cfg.QuarantineMessageUrl = srv.URL
+
+	t.Run(testDescription, testMessageProcessingQuarantine(
+		messageToSend,
+		cfg.EqReceiptTopic, cfg.EqReceiptProject))
+
+	time.Sleep(1 * time.Second)
+
+	if len(requests) != 1 {
+		t.Errorf("Unexpected number of calls to Exception Manager")
+		return
+	}
+
+	var quarantineBody models.MessageToQuarantine
+	err := json.Unmarshal(requestBody, &quarantineBody)
+	if err != nil {
+		t.Errorf("Could not decode request body sent to Exception Manager")
+		return
+	}
+
+	if assertEqual("application/json", quarantineBody.ContentType, "Dodgy content type", t) {
+		return
+	}
+
+	if assertEqual("Error unmarshalling message", quarantineBody.ExceptionClass, "Dodgy exception class", t) {
+		return
+	}
+
+	if assertEqual(1, len(quarantineBody.Headers), "Dodgy headers", t) {
+		return
+	}
+
+	if len(quarantineBody.Headers["pubSubId"]) == 0 {
+		t.Errorf("Dodgy pubSubId header, expected non-zero length")
+		return
+	}
+
+	if assertEqual(64, len(quarantineBody.MessageHash), "Dodgy message hash", t) {
+		return
+	}
+
+	if assertEqual(messageToSend, string(quarantineBody.MessagePayload), "Dodgy message payload", t) {
+		return
+	}
+
+	if assertEqual(cfg.EqReceiptSubscription, quarantineBody.Queue, "Dodgy quarantine queue", t) {
+		return
+	}
+
+	if assertEqual("none", quarantineBody.RoutingKey, "Dodgy routing key", t) {
+		return
+	}
+
+	if assertEqual("Pubsub Adapter", quarantineBody.Service, "Dodgy routing key", t) {
+		return
+	}
+}
+
+func assertEqual(expected interface{}, actual interface{}, feedback string, t *testing.T) bool {
+	if expected != actual {
+		t.Errorf("%v, expected %v, actual %v", feedback, expected, actual)
+		return true
+	}
+
+	return false
 }
 
 func testMessageProcessing(messageToSend string, expectedRabbitMessage string, topic string, project string, rabbitRoutingKey string) func(t *testing.T) {
@@ -126,6 +206,25 @@ func testMessageProcessing(messageToSend string, expectedRabbitMessage string, t
 		if rabbitMessage != expectedRabbitMessage {
 			t.Errorf("Rabbit messsage incorrect - \nexpected: %s \nactual: %s", expectedRabbitMessage, rabbitMessage)
 		}
+		cancel()
+	}
+}
+
+func testMessageProcessingQuarantine(messageToSend string, topic string, project string) func(t *testing.T) {
+	return func(t *testing.T) {
+		if _, err := StartProcessors(ctx, cfg, make(chan error)); err != nil {
+			t.Error(err)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+		// When
+		if messageId, err := publishMessageToPubSub(ctx, messageToSend, topic, project); err != nil {
+			t.Errorf("PubSub publish fail, project: %s, topic: %s, id: %s, error: %s", project, topic, messageId, err)
+			return
+		}
+
 		cancel()
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -126,15 +126,14 @@ func testMessageQuarantining(messageToSend string, testDescription string, t *te
 		return
 	}
 
-	if assertEqual("application/json", quarantineBody.ContentType, "Dodgy content type", t) {
-		return
-	}
-
-	if assertEqual("Error unmarshalling message", quarantineBody.ExceptionClass, "Dodgy exception class", t) {
-		return
-	}
-
-	if assertEqual(1, len(quarantineBody.Headers), "Dodgy headers", t) {
+	if !assertEqual("application/json", quarantineBody.ContentType, "Dodgy content type", t) ||
+		!assertEqual("Error unmarshalling message", quarantineBody.ExceptionClass, "Dodgy exception class", t) ||
+		!assertEqual(1, len(quarantineBody.Headers), "Dodgy headers", t) ||
+		!assertEqual(64, len(quarantineBody.MessageHash), "Dodgy message hash", t) ||
+		!assertEqual(messageToSend, string(quarantineBody.MessagePayload), "Dodgy message payload", t) ||
+		!assertEqual(cfg.EqReceiptSubscription, quarantineBody.Queue, "Dodgy quarantine queue", t) ||
+		!assertEqual("none", quarantineBody.RoutingKey, "Dodgy routing key", t) ||
+		!assertEqual("Pubsub Adapter", quarantineBody.Service, "Dodgy routing key", t) {
 		return
 	}
 
@@ -142,35 +141,15 @@ func testMessageQuarantining(messageToSend string, testDescription string, t *te
 		t.Errorf("Dodgy pubSubId header, expected non-zero length")
 		return
 	}
-
-	if assertEqual(64, len(quarantineBody.MessageHash), "Dodgy message hash", t) {
-		return
-	}
-
-	if assertEqual(messageToSend, string(quarantineBody.MessagePayload), "Dodgy message payload", t) {
-		return
-	}
-
-	if assertEqual(cfg.EqReceiptSubscription, quarantineBody.Queue, "Dodgy quarantine queue", t) {
-		return
-	}
-
-	if assertEqual("none", quarantineBody.RoutingKey, "Dodgy routing key", t) {
-		return
-	}
-
-	if assertEqual("Pubsub Adapter", quarantineBody.Service, "Dodgy routing key", t) {
-		return
-	}
 }
 
 func assertEqual(expected interface{}, actual interface{}, feedback string, t *testing.T) bool {
 	if expected != actual {
 		t.Errorf("%v, expected %v, actual %v", feedback, expected, actual)
-		return true
+		return false
 	}
 
-	return false
+	return true
 }
 
 func testMessageProcessing(messageToSend string, expectedRabbitMessage string, topic string, project string, rabbitRoutingKey string) func(t *testing.T) {

--- a/models/messageToQuarantine.go
+++ b/models/messageToQuarantine.go
@@ -1,0 +1,12 @@
+package models
+
+type MessageToQuarantine struct {
+	MessageHash    string            `json:"messageHash"`
+	MessagePayload []byte            `json:"messagePayload"`
+	Service        string            `json:"service"`
+	Queue          string            `json:"queue"`
+	ExceptionClass string            `json:"exceptionClass"`
+	RoutingKey     string            `json:"routingKey"`
+	ContentType    string            `json:"contentType"`
+	Headers        map[string]string `json:"headers"`
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/streadway/amqp"
 	"go.uber.org/zap"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -161,12 +160,12 @@ func (p *Processor) quarantineMessage(message *pubsub.Message) error {
 		Headers:        headers,
 	}
 
-	jsonValue, _ := json.Marshal(msgToQuarantine)
-	response, err := http.Post(p.Config.QuarantineMessageUrl, "application/json", bytes.NewBuffer(jsonValue))
+	jsonValue, err := json.Marshal(msgToQuarantine)
 	if err != nil {
 		return err
 	}
-	_, err = ioutil.ReadAll(response.Body)
+
+	_, err = http.Post(p.Config.QuarantineMessageUrl, "application/json", bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Motivation and Context
For speed of development during the rehearsal, we didn't make the Exception Manager persistent. We now need to have the service backed by a persistent data store instead of using a Rabbit queue to save the quarantined messages.

# What has changed
Added persistence.

# How to test?
Publish a bad message onto a PubSub topic. Check the `exceptionmanager` database.

# Links
Trello: https://trello.com/c/sYuR2Vgw