### PR TITLE
Transactional publishing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Configuration struct {
-	ReadinessFilePath    string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
-	LogLevel             string `envconfig:"LOG_LEVEL" default:"ERROR"`
-	QuarantineMessageUrl string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
+	ReadinessFilePath      string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
+	LogLevel               string `envconfig:"LOG_LEVEL" default:"ERROR"`
+	QuarantineMessageUrl   string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
+	PublishersPerProcessor int    `envconfig:"PUBLISHERS_PER_PROCESSOR" default:"20"`
 
 	// Rabbit
 	RabbitHost             string `envconfig:"RABBIT_HOST" required:"true"`

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func shutdown(ctx context.Context, cancel context.CancelFunc, processors []*proc
 
 		logger.Logger.Info("Starting rabbit cleanup")
 		for _, p := range processors {
-			p.CloseRabbit()
+			p.CloseRabbit(false)
 		}
 
 	}()

--- a/main_test.go
+++ b/main_test.go
@@ -233,9 +233,6 @@ func TestRabbitReconnect(t *testing.T) {
 	// Take the first processor
 	processor := processors[0]
 
-
-	time.Sleep(1 * time.Second)
-
 	// Pick one of the processors rabbit channels
 	var channel *amqp.Channel
 	for channel == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -191,7 +191,6 @@ func assertEqual(expected interface{}, actual interface{}, feedback string, t *t
 	return true
 }
 
-
 func testMessageProcessingQuarantine(messageToSend string, topic string, project string) func(t *testing.T) {
 	return func(t *testing.T) {
 		if _, err := StartProcessors(ctx, cfg, make(chan error)); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -233,8 +233,6 @@ func TestRabbitReconnect(t *testing.T) {
 	// Take the first processor
 	processor := processors[0]
 
-	// Set up a notify close on all the processors rabbit channels
-	channelErrChan := make(chan *amqp.Error)
 
 	time.Sleep(1 * time.Second)
 
@@ -245,6 +243,7 @@ func TestRabbitReconnect(t *testing.T) {
 			channel = processor.RabbitChannels[0]
 		}
 	}
+	channelErrChan := make(chan *amqp.Error)
 	channel.NotifyClose(channelErrChan)
 
 	// Check the processors rabbit channel can publish

--- a/main_test.go
+++ b/main_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 	runtime.GOMAXPROCS(1)
 	ctx = context.Background()
 	cfg = &config.Configuration{
+		PublishersPerProcessor:          1,
 		RabbitConnectionString:          "amqp://guest:guest@localhost:7672/",
 		ReceiptRoutingKey:               "goTestReceiptQueue",
 		UndeliveredRoutingKey:           "goTestUndeliveredQueue",

--- a/models/outboundMessage.go
+++ b/models/outboundMessage.go
@@ -1,0 +1,8 @@
+package models
+
+import "cloud.google.com/go/pubsub"
+
+type OutboundMessage struct {
+	EventMessage  *RmMessage
+	SourceMessage *pubsub.Message
+}


### PR DESCRIPTION
# Motivation and Context
The current code does not publish transactionally so has the potential to lose messages if it acks the source PubSub message but fails to publish. Transactional publishing is, however, a lot slower and cannot be done concurrently with a single publishing channel. Hence, to avoid performance loss, this PR also allows a configurable number of publisher workers with their own channel each to overcome the performance loss.
In my performance testing I found that 20 publishers per processor roughly brought the same performance over our 5000 PubSub message performance test as before.

# What has changed
* Spin up a configurable number of publishing workers per processor
* Give each publishing worker a transactional rabbit channel
* Update reconnection logic to restart all of a processors publishers if there is a rabbit connection/channel closure
* Update rabbit reconnection integration test

# How to test?
Run the acceptance tests against this branch to check regression, run the 5000 PubSub performance test. You should see times roughly equal to the performance on master.

# Links
https://trello.com/c/SKxD063x/997-spike-pubsub-adapter-safe-rabbit-publishing-with-transactions-1-day
