### PR TITLE
Fix bugs in rabbit connection init and close

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -222,12 +222,12 @@ func TestStartProcessors(t *testing.T) {
 	}
 }
 
-func TestRabbitReconnect(t *testing.T) {
+func TestRabbitReconnectOnChannelDeath(t *testing.T) {
 	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Start up the processors normally
-	processors, err := StartProcessors(ctx, cfg, make(chan error))
+	processors, err := StartProcessors(timeout, cfg, make(chan error))
 	if err != nil {
 		t.Error(err)
 		return
@@ -288,6 +288,61 @@ func TestRabbitReconnect(t *testing.T) {
 					continue
 				}
 				channel := processor.RabbitChannels[0]
+				if err := publishToRabbit(channel, cfg.EventsExchange, cfg.ReceiptRoutingKey, `{"test":"message should publish after"}`); err == nil {
+					// We have successfully published a message with the processors re-opened rabbit channel
+					success <- true
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-timeout.Done():
+		t.Error("Failed to publish message with processors channel within the timeout")
+		return
+	case <-success:
+		return
+	}
+}
+
+func TestRabbitReconnectOnBadConnection(t *testing.T) {
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Induce a connection failure by using the wrong connection string
+	brokenCfg := *cfg
+	brokenCfg.RabbitConnectionString = "bad-connection-string"
+
+	// Start up the processors normally
+	processors, err := StartProcessors(timeout, &brokenCfg, make(chan error))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	// Take the first processor
+	testProcessor := processors[0]
+
+	// Give it a second to attempt connection and fail
+	time.Sleep(1*time.Second)
+
+	// Fix the config
+	testProcessor.Config.RabbitConnectionString = cfg.RabbitConnectionString
+
+	// Try to successfully publish a message using the processors channel within the timeout
+	success := make(chan bool)
+	go func() {
+		for {
+			select {
+			case <-timeout.Done():
+				// Kill this goroutine if the test times out
+				return
+			default:
+				// Repeatedly try to publish a message using the processors channel
+				if len(testProcessor.RabbitChannels) == 0 {
+					continue
+				}
+				channel := testProcessor.RabbitChannels[0]
 				if err := publishToRabbit(channel, cfg.EventsExchange, cfg.ReceiptRoutingKey, `{"test":"message should publish after"}`); err == nil {
 					// We have successfully published a message with the processors re-opened rabbit channel
 					success <- true

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -155,7 +155,7 @@ func (p *Processor) ManagePublishers(ctx context.Context) {
 			p.startPublishers(ctx, publisherCancel)
 
 			// Sleep for a second here so it doesn't bombard rabbit with reconnection attempts at a ridiculous rate
-			time.Sleep(1*time.Second)
+			time.Sleep(1 * time.Second)
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
# Motivation and Context
Has bug, not good
When completely failing to connect to rabbit, errors were not handled and it was starting up without any running publishers. The shutdown close would also panic on nil pointers if it was called before a connection had been established.

# What has changed
* Fix bug in rabbit connection open
* Fix bug in rabbit connection close
* Add test for reconnecting on failed connection

# How to test?
Try to start the app before it's rabbit dependency, then bring up rabbit. It should initially fail to connect until rabbit it there, then connect successfully

# Links
https://trello.com/c/48pgUBmy/1022-pubsub-adapter-fix-rabbit-connection-bugs