### PR TITLE
Processor Restarts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type Configuration struct {
 	QuarantineMessageUrl        string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
 	PublishersPerProcessor      int    `envconfig:"PUBLISHERS_PER_PROCESSOR" default:"20"`
 	ProcessorRestartWaitSeconds int    `envconfig:"PROCESSOR_RESTART_WAIT_SECONDS" default:"5"`
+	ProcessorStartUpTimeSeconds int    `envconfig:"PROCESSOR_START_UP_TIME_SECONDS default:"5"`
 
 	// Rabbit
 	RabbitHost                       string `envconfig:"RABBIT_HOST" required:"true"`
@@ -51,6 +52,7 @@ var cfg *Configuration
 var TestConfig = &Configuration{
 	PublishersPerProcessor:           1,
 	ProcessorRestartWaitSeconds:      1,
+	ProcessorStartUpTimeSeconds:      1,
 	ReadinessFilePath:                "/tmp/pubsub-adapter-ready",
 	RabbitConnectionString:           "amqp://guest:guest@localhost:7672/",
 	ReceiptRoutingKey:                "goTestReceiptQueue",

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Configuration struct {
 	QuarantineMessageUrl        string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
 	PublishersPerProcessor      int    `envconfig:"PUBLISHERS_PER_PROCESSOR" default:"20"`
 	ProcessorRestartWaitSeconds int    `envconfig:"PROCESSOR_RESTART_WAIT_SECONDS" default:"5"`
-	ProcessorStartUpTimeSeconds int    `envconfig:"PROCESSOR_START_UP_TIME_SECONDS default:"5"`
+	ProcessorStartUpTimeSeconds int    `envconfig:"PROCESSOR_START_UP_TIME_SECONDS" default:"5"`
 
 	// Rabbit
 	RabbitHost                       string `envconfig:"RABBIT_HOST" required:"true"`

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ var cfg *Configuration
 var TestConfig = &Configuration{
 	PublishersPerProcessor:           1,
 	RestartTimeout:                  5,
+	ReadinessFilePath:               "/tmp/pubsub-adapter-ready",
 	RabbitConnectionString:           "amqp://guest:guest@localhost:7672/",
 	ReceiptRoutingKey:                "goTestReceiptQueue",
 	UndeliveredRoutingKey:            "goTestUndeliveredQueue",

--- a/config/config.go
+++ b/config/config.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Configuration struct {
-	ReadinessFilePath      string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
-	LogLevel               string `envconfig:"LOG_LEVEL" default:"ERROR"`
-	QuarantineMessageUrl   string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
-	PublishersPerProcessor int    `envconfig:"PUBLISHERS_PER_PROCESSOR" default:"20"`
-	RestartTimeout         int    `envconfig:"RESTART_TIMEOUT" default:"120"`
+	ReadinessFilePath           string `envconfig:"READINESS_FILE_PATH" default:"/tmp/pubsub-adapter-ready"`
+	LogLevel                    string `envconfig:"LOG_LEVEL" default:"ERROR"`
+	QuarantineMessageUrl        string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
+	PublishersPerProcessor      int    `envconfig:"PUBLISHERS_PER_PROCESSOR" default:"20"`
+	ProcessorRestartWaitSeconds int    `envconfig:"PROCESSOR_RESTART_WAIT_SECONDS" default:"5"`
 
 	// Rabbit
 	RabbitHost                       string `envconfig:"RABBIT_HOST" required:"true"`
@@ -50,7 +50,7 @@ type Configuration struct {
 var cfg *Configuration
 var TestConfig = &Configuration{
 	PublishersPerProcessor:           1,
-	RestartTimeout:                  5,
+	ProcessorRestartWaitSeconds:     1,
 	ReadinessFilePath:               "/tmp/pubsub-adapter-ready",
 	RabbitConnectionString:           "amqp://guest:guest@localhost:7672/",
 	ReceiptRoutingKey:                "goTestReceiptQueue",

--- a/config/config.go
+++ b/config/config.go
@@ -50,8 +50,8 @@ type Configuration struct {
 var cfg *Configuration
 var TestConfig = &Configuration{
 	PublishersPerProcessor:           1,
-	ProcessorRestartWaitSeconds:     1,
-	ReadinessFilePath:               "/tmp/pubsub-adapter-ready",
+	ProcessorRestartWaitSeconds:      1,
+	ReadinessFilePath:                "/tmp/pubsub-adapter-ready",
 	RabbitConnectionString:           "amqp://guest:guest@localhost:7672/",
 	ReceiptRoutingKey:                "goTestReceiptQueue",
 	UndeliveredRoutingKey:            "goTestUndeliveredQueue",

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ type Configuration struct {
 	LogLevel               string `envconfig:"LOG_LEVEL" default:"ERROR"`
 	QuarantineMessageUrl   string `envconfig:"QUARANTINE_MESSAGE_URL"  required:"true"`
 	PublishersPerProcessor int    `envconfig:"PUBLISHERS_PER_PROCESSOR" default:"20"`
+	RestartTimeout         int    `envconfig:"RESTART_TIMEOUT" default:"120"`
 
 	// Rabbit
 	RabbitHost                       string `envconfig:"RABBIT_HOST" required:"true"`
@@ -49,6 +50,7 @@ type Configuration struct {
 var cfg *Configuration
 var TestConfig = &Configuration{
 	PublishersPerProcessor:           1,
+	RestartTimeout:                  5,
 	RabbitConnectionString:           "amqp://guest:guest@localhost:7672/",
 	ReceiptRoutingKey:                "goTestReceiptQueue",
 	UndeliveredRoutingKey:            "goTestUndeliveredQueue",

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func RunLoop(ctx context.Context, cfg *config.Configuration, signals chan os.Sig
 			// Wait for successful start up
 			if err := waitForStartup(ctx, cfg, errChan); err != nil {
 				// Requeue the error if restart was not successful so that it is retried
-				go processorErr.QueueError(err)
+				processorErr.ReportError(err)
 			} else {
 				logger.Logger.Infow("Successfully restarted processor", "processor", processorErr.Name)
 			}

--- a/main.go
+++ b/main.go
@@ -73,14 +73,6 @@ func RunLoop(ctx context.Context, cfg *config.Configuration, signals chan os.Sig
 
 			processorErr.Restart(ctx)
 
-			// Wait for successful start up
-			if err := waitForStartup(ctx, cfg, errChan); err != nil {
-				// Requeue the error if restart was not successful so that it is retried
-				processorErr.ReportError(err)
-			} else {
-				logger.Logger.Infow("Successfully restarted processor", "processor", processorErr.Name)
-			}
-
 			// Limit the rate of restarts
 			time.Sleep(time.Duration(cfg.ProcessorRestartWaitSeconds) * time.Second)
 		}

--- a/main.go
+++ b/main.go
@@ -33,11 +33,17 @@ func main() {
 	signal.Notify(signals, os.Interrupt)
 
 	// Channel for goroutines to notify main of errors
-	errChan := make(chan error)
+	errChan := make(chan processor.Error)
 
 	processors, err := StartProcessors(ctx, appConfig, errChan)
 	if err != nil {
 		logger.Logger.Errorw("Error starting processors", "error", err)
+		shutdown(ctx, cancel, processors)
+	}
+
+	// Wait for processors to start properly
+	if err := waitForStartup(ctx, errChan); err != nil {
+		logger.Logger.Info("Shutting down due to start up error")
 		shutdown(ctx, cancel, processors)
 	}
 	// Indicate readiness
@@ -46,52 +52,87 @@ func main() {
 		logger.Logger.Errorw("Error indicating readiness", "error", err)
 		shutdown(ctx, cancel, processors)
 	}
+	defer shutdown(ctx, cancel, processors)
 
 	// Block until we receive OS shutdown signal or error
-	select {
-	case sig := <-signals:
-		logger.Logger.Infow("OS Signal Received", "signal", sig.String())
-	case err := <-errChan:
-		// TODO Make some attempt to restart receivers so one error doesn't kill them all immediately
-		logger.Logger.Errorw("Error Received", "error", err)
-	}
+	RunLoop(ctx, appConfig, signals, errChan)
+}
 
-	shutdown(ctx, cancel, processors)
+func RunLoop(ctx context.Context, cfg *config.Configuration, signals chan os.Signal, errChan chan processor.Error) {
+	for {
+		select {
+		case sig := <-signals:
+			logger.Logger.Infow("OS Signal Received", "signal", sig.String())
+			return
+		case processorErr := <-errChan:
+			logger.Logger.Errorw("Processor error received", "error", processorErr.Err, "processor", processorErr.Name)
+			processorErr.Stop()
+			//if err := readiness.Unready(cfg.ReadinessFilePath); err != nil {
+			//	logger.Logger.Errorw("Error showing not ready", "error", err)
+			//}
+			if err := processorErr.Initialise(ctx); err != nil {
+				logger.Logger.Errorw("Failed to restart processor", "error", err, "processor", processorErr.Name)
+				go QueueError(processor.Error{
+					Err: err,
+					Processor: processorErr.Processor,
+				}, errChan)
+			} else if err := waitForStartup(ctx, errChan); err != nil {
+				go QueueError(processor.Error{
+					Err: err,
+					Processor: processorErr.Processor,
+				}, errChan)
+			}
+
+			// Limit the rate of restarts
+			time.Sleep(1 * time.Second)
+
+			//if err := readiness.Ready(ctx, cfg.ReadinessFilePath); err != nil {
+			//	logger.Logger.Errorw("Error showing ready", "error", err)
+			//}
+		}
+	}
+}
+
+func QueueError(err processor.Error, errChan chan processor.Error) {
+	errChan <- err
+}
+
+func RestartProcessor(ctx context.Context, p *processor.Processor, errChan chan processor.Error) {
 
 }
 
-func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan chan error) ([]*processor.Processor, error) {
+func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan chan processor.Error) ([]*processor.Processor, error) {
 	processors := make([]*processor.Processor, 0)
 
-	// Start EQ receipt processing
+	// Initialise EQ receipt processing
 	eqReceiptProcessor, err := processor.NewEqReceiptProcessor(ctx, cfg, errChan)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error starting eQ receipt processor")
 	}
 	processors = append(processors, eqReceiptProcessor)
 
-	// Start offline receipt processing
+	// Initialise offline receipt processing
 	offlineReceiptProcessor, err := processor.NewOfflineReceiptProcessor(ctx, cfg, errChan)
 	if err != nil {
 		return processors, errors.Wrap(err, "Error starting offline receipt processor")
 	}
 	processors = append(processors, offlineReceiptProcessor)
 
-	// Start PPO undelivered processing
+	// Initialise PPO undelivered processing
 	ppoUndeliveredProcessor, err := processor.NewPpoUndeliveredProcessor(ctx, cfg, errChan)
 	if err != nil {
 		return processors, errors.Wrap(err, "Error starting PPO undelivered processor")
 	}
 	processors = append(processors, ppoUndeliveredProcessor)
 
-	// Start QM undelivered processing
+	// Initialise QM undelivered processing
 	qmUndeliveredProcessor, err := processor.NewQmUndeliveredProcessor(ctx, cfg, errChan)
 	if err != nil {
 		return processors, errors.Wrap(err, "Error starting QM undelivered processor")
 	}
 	processors = append(processors, qmUndeliveredProcessor)
 
-	// Start fulfilment confirmed processing
+	// Initialise fulfilment confirmed processing
 	fulfilmentConfirmedProcessor, err := processor.NewFulfilmentConfirmedProcessor(ctx, cfg, errChan)
 	if err != nil {
 		return processors, errors.Wrap(err, "Error starting fulfilment confirmed processor")
@@ -105,6 +146,19 @@ func StartProcessors(ctx context.Context, cfg *config.Configuration, errChan cha
 	processors = append(processors, eqFulfilmentProcessor)
 
 	return processors, nil
+}
+
+func waitForStartup(ctx context.Context, errChan chan processor.Error) error {
+	startupTimer, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	select {
+	case processorError := <-errChan:
+		processorError.Logger.Errorw("Processor errored during startup period", "error", processorError.Err)
+		return processorError.Err
+	case <-startupTimer.Done():
+		logger.Logger.Debug("Startup complete")
+		return nil
+	}
 }
 
 func shutdown(ctx context.Context, cancel context.CancelFunc, processors []*processor.Processor) {

--- a/main_test.go
+++ b/main_test.go
@@ -226,7 +226,7 @@ func TestRabbitReconnectOnChannelDeath(t *testing.T) {
 	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	// Start up the processors normally
+	// Initialise up the processors normally
 	processors, err := StartProcessors(timeout, cfg, make(chan error))
 	if err != nil {
 		assert.NoError(t, err)
@@ -295,7 +295,7 @@ func TestRabbitReconnectOnBadConnection(t *testing.T) {
 	brokenCfg := *cfg
 	brokenCfg.RabbitConnectionString = "bad-connection-string"
 
-	// Start up the processors normally
+	// Initialise up the processors normally
 	processors, err := StartProcessors(timeout, &brokenCfg, make(chan error))
 	if err != nil {
 		assert.NoError(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -240,7 +240,7 @@ func TestRabbitReconnectOnChannelDeath(t *testing.T) {
 	assert.NoError(t, ready.Ready())
 
 	// Start the run loop
-	go RunLoop(timeout, cfg, nil, errChan, ready)
+	go RunLoop(timeout, cfg, nil, errChan)
 
 	// Take the first testProcessor
 	testProcessor := processors[0]
@@ -313,7 +313,7 @@ func TestRabbitReconnectOnBadConnection(t *testing.T) {
 	assert.NoError(t, ready.Ready())
 
 	// Start the run loop
-	go RunLoop(timeout, cfg, nil, errChan, ready)
+	go RunLoop(timeout, cfg, nil, errChan)
 
 	// Take the first processor
 	testProcessor := processors[0]
@@ -353,7 +353,7 @@ func TestProcessorGracefullyReinitializeRabbitChannels(t *testing.T) {
 	// Take the first processor, for example
 	testProcessor := processors[0]
 
-	// Grab one of it's rabbit channels and subscribe to it's close notifications
+	// Grab one of its rabbit channels and subscribe to its close notifications
 	channel, ok := getRabbitChannelFromProcessor(timeout, testProcessor)
 	if !ok {
 		assert.Fail(t, "Failed to get a rabbit channel from the processor within the timeout")
@@ -362,7 +362,7 @@ func TestProcessorGracefullyReinitializeRabbitChannels(t *testing.T) {
 	rabbitErrChan := make(chan *amqp.Error)
 	channel.NotifyClose(rabbitErrChan)
 
-	go RunLoop(timeout, cfg, nil, errChan, new(readiness.Readiness))
+	go RunLoop(timeout, cfg, nil, errChan)
 
 	// Simulate an error
 	errChan <- processor.Error{

--- a/processor/eqFulfilmentProcessor.go
+++ b/processor/eqFulfilmentProcessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewEqFulfilmentProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+func NewEqFulfilmentProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan Error) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.EqFulfilmentProject, appConfig.EqFulfilmentSubscription, appConfig.FulfilmentRequestRoutingKey, convertEqFulfilment, unmarshalEqFulfilment, errChan)
 }
 

--- a/processor/eqReceiptProcessor.go
+++ b/processor/eqReceiptProcessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+func NewEqReceiptProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan Error) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.EqReceiptProject, appConfig.EqReceiptSubscription, appConfig.ReceiptRoutingKey, convertEqReceiptToRmMessage, unmarshalEqReceipt, errChan)
 }
 

--- a/processor/fulfilmentConfirmedProcessor.go
+++ b/processor/fulfilmentConfirmedProcessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewFulfilmentConfirmedProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+func NewFulfilmentConfirmedProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan Error) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.FulfilmentConfirmedProject, appConfig.FulfilmentConfirmedSubscription, appConfig.FulfilmentConfirmationRoutingKey, convertFulfilmentConfirmedToRmMessage, unmarshalFulfilmentConfirmed, errChan)
 }
 

--- a/processor/offlineReceiptProcessor.go
+++ b/processor/offlineReceiptProcessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+func NewOfflineReceiptProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan Error) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.OfflineReceiptProject, appConfig.OfflineReceiptSubscription, appConfig.ReceiptRoutingKey, convertOfflineReceiptToRmMessage, unmarshalOfflineReceipt, errChan)
 }
 

--- a/processor/ppoUndeliveredProcessor.go
+++ b/processor/ppoUndeliveredProcessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+func NewPpoUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan Error) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.PpoUndeliveredProject, appConfig.PpoUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertPpoUndeliveredToRmMessage, unmarshalPpoUndelivered, errChan)
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -176,3 +176,19 @@ func (p *Processor) Stop() {
 	p.Cancel()
 	p.CloseRabbit(false)
 }
+
+func (p *Processor) Restart(ctx context.Context) {
+	p.Stop()
+	if err := p.Initialise(ctx); err != nil {
+		logger.Logger.Errorw("Failed to restart processor", "error", err, "processor", p.Name)
+		go p.QueueError(err)
+	}
+
+}
+
+func (p *Processor) QueueError(err error) {
+	p.ErrChan <- Error{
+		Err:       err,
+		Processor: p,
+	}
+}

--- a/processor/publisher.go
+++ b/processor/publisher.go
@@ -78,10 +78,7 @@ func (p *Processor) sendProcessorErrorOnRabbitError(firstRabbitErr <-chan *amqp.
 	// We only consume off this channel once to trigger the processor restart on the first error
 	select {
 	case err := <-firstRabbitErr:
-		p.ErrChan <- Error{
-			Err:       errors.Wrap(err, "rabbit connection or channel error"),
-			Processor: p,
-		}
+		p.ReportError(errors.Wrap(err, "rabbit connection or channel error"))
 	case <-p.Context.Done():
 		return
 	}
@@ -91,10 +88,7 @@ func (p *Processor) startPublishers(ctx context.Context) {
 	// Setup one rabbit connection
 	if err := p.initRabbitConnection(); err != nil {
 		p.Logger.Errorw("Error initialising rabbit connection", "error", err)
-		p.ErrChan <- Error{
-			Err:       err,
-			Processor: p,
-		}
+		p.ReportError(err)
 		return
 	}
 

--- a/processor/publisher.go
+++ b/processor/publisher.go
@@ -29,7 +29,7 @@ func (p *Processor) initRabbitConnection() error {
 	return nil
 }
 
-func (p *Processor) initRabbitChannel(cancelFunc context.CancelFunc) (RabbitChannel, error) {
+func (p *Processor) initRabbitChannel() (RabbitChannel, error) {
 	var err error
 	var channel *amqp.Channel
 
@@ -48,11 +48,23 @@ func (p *Processor) initRabbitChannel(cancelFunc context.CancelFunc) (RabbitChan
 	// Listen for errors on the rabbit channel to handle both channel specific and connection wide exceptions
 	channelErrChan := make(chan *amqp.Error)
 	go func() {
-		channelErr := <-channelErrChan
+		select {
+		case channelErr := <-channelErrChan:
 
 		// TODO handle reconnecting in graceful processor restart rather than a direct call to reinitialize here
-		p.Logger.Errorw("received rabbit channel error", "error", channelErr)
-		cancelFunc()
+		if channelErr != nil {
+			p.Logger.Errorw("received rabbit channel error", "error", channelErr)
+			p.ErrChan <- Error{
+				Err:       channelErr,
+				Processor: p,
+			}
+		} else {
+			p.Logger.Debug("Rabbit channel shutting down")
+		}
+		case <-p.Context.Done():
+			return
+		}
+
 	}()
 	channel.NotifyClose(channelErrChan)
 	p.RabbitChannels = append(p.RabbitChannels, channel)
@@ -60,11 +72,14 @@ func (p *Processor) initRabbitChannel(cancelFunc context.CancelFunc) (RabbitChan
 	return channel, nil
 }
 
-func (p *Processor) startPublishers(ctx context.Context, publisherCancel context.CancelFunc) {
+func (p *Processor) startPublishers(ctx context.Context) {
 	// Setup one rabbit connection
 	if err := p.initRabbitConnection(); err != nil {
 		p.Logger.Errorw("Error initialising rabbit connection", "error", err)
-		publisherCancel()
+		p.ErrChan <- Error{
+			Err:       err,
+			Processor: p,
+		}
 		return
 	}
 
@@ -73,35 +88,11 @@ func (p *Processor) startPublishers(ctx context.Context, publisherCancel context
 	for i := 0; i < p.Config.PublishersPerProcessor; i++ {
 
 		// Open a rabbit channel for each publisher worker
-		channel, err := p.initRabbitChannel(publisherCancel)
+		channel, err := p.initRabbitChannel()
 		if err != nil {
 			return
 		}
 		go p.Publish(ctx, channel)
-	}
-}
-
-func (p *Processor) ManagePublishers(ctx context.Context) {
-
-	publisherCtx, publisherCancel := context.WithCancel(context.Background())
-	p.startPublishers(ctx, publisherCancel)
-
-	for {
-		select {
-		case <-publisherCtx.Done():
-			// Use a publisher context to restart publishers on rabbit connection or channel errors
-			// TODO replace this with graceful processor restarting
-			publisherCtx, publisherCancel = context.WithCancel(context.Background())
-			p.Logger.Info("Restarting publishers")
-
-			// Tidy up the current connection and any open channels
-			p.CloseRabbit(true)
-
-			// Restart publishers
-			p.startPublishers(ctx, publisherCancel)
-		case <-ctx.Done():
-			return
-		}
 	}
 }
 
@@ -158,6 +149,10 @@ func (p *Processor) publishEventToRabbit(message *models.RmMessage, routingKey s
 
 	p.Logger.Debugw("Published message", "routingKey", routingKey, "transactionId", message.Event.TransactionID)
 	return nil
+}
+
+func (p *Processor) StopPublishers() {
+
 }
 
 func (p *Processor) CloseRabbit(errOk bool) {

--- a/processor/qmUndeliveredProcessor.go
+++ b/processor/qmUndeliveredProcessor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ONSdigital/census-rm-pubsub-adapter/models"
 )
 
-func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan error) (*Processor, error) {
+func NewQmUndeliveredProcessor(ctx context.Context, appConfig *config.Configuration, errChan chan Error) (*Processor, error) {
 	return NewProcessor(ctx, appConfig, appConfig.QmUndeliveredProject, appConfig.QmUndeliveredSubscription, appConfig.UndeliveredRoutingKey, convertQmUndeliveredToRmMessage, unmarshalQmUndelivered, errChan)
 }
 

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -20,10 +20,14 @@ func Ready(ctx context.Context, readinessFilePath string) error {
 	return nil
 }
 
+func Unready(readinessFilePath string) error {
+	return os.Remove(readinessFilePath)
+}
+
 func removeReadyWhenDone(ctx context.Context, readinessFilePath string) {
 	<-ctx.Done()
 	logger.Logger.Info("Removing readiness file")
-	err := os.Remove(readinessFilePath)
+	err := Unready(readinessFilePath)
 	if err != nil {
 		logger.Logger.Errorw("Error removing readiness file", "readinessFilePath", readinessFilePath, "error", err)
 	}

--- a/readiness/readiness.go
+++ b/readiness/readiness.go
@@ -6,29 +6,37 @@ import (
 	"os"
 )
 
-func Ready(ctx context.Context, readinessFilePath string) error {
-	_, err := os.Stat(readinessFilePath)
-	if err == nil {
-		logger.Logger.Errorw("Readiness file already existed", "readinessFilePath", readinessFilePath)
+type Readiness struct {
+	FilePath string
+	IsReady  bool
+}
+
+func New(ctx context.Context, filePath string) *Readiness {
+	readiness := &Readiness{FilePath: filePath, IsReady: false}
+	go readiness.removeReadyWhenDone(ctx)
+	return readiness
+}
+
+func (r *Readiness) Ready() error {
+	if _, err := os.Stat(r.FilePath); err == nil {
+		logger.Logger.Warnw("Readiness file already existed", "readinessFilePath", r.FilePath)
 	}
-	_, err = os.Create(readinessFilePath)
-	if err != nil {
+	if _, err := os.Create(r.FilePath); err != nil {
 		return err
 	}
-	go removeReadyWhenDone(ctx, readinessFilePath)
-
+	r.IsReady = true
 	return nil
 }
 
-func Unready(readinessFilePath string) error {
-	return os.Remove(readinessFilePath)
+func (r *Readiness) Unready() error {
+	r.IsReady = false
+	return os.Remove(r.FilePath)
 }
 
-func removeReadyWhenDone(ctx context.Context, readinessFilePath string) {
+func (r *Readiness) removeReadyWhenDone(ctx context.Context) {
 	<-ctx.Done()
 	logger.Logger.Info("Removing readiness file")
-	err := Unready(readinessFilePath)
-	if err != nil {
-		logger.Logger.Errorw("Error removing readiness file", "readinessFilePath", readinessFilePath, "error", err)
+	if err := r.Unready(); err != nil {
+		logger.Logger.Errorw("Error removing readiness file", "readinessFilePath", r.FilePath, "error", err)
 	}
 }

--- a/readiness/readiness_test.go
+++ b/readiness/readiness_test.go
@@ -53,7 +53,6 @@ func testReadinessFiles(t *testing.T) {
 	// Check the readiness object is ready
 	assert.True(t, readiness.IsReady)
 
-
 	// Trigger the cancel which should result in the file being removed
 	readinessCancel()
 


### PR DESCRIPTION
# Motivation and Context
Enable processor restarts on errors from the rabbit channels and pubsub receiver so that the entire app is not immediatelly killed.

# What has changed
* Attempt to restart processors on errors on the error channel
* Send rabbit channel errors to the error channel
* Introduce a short delay on showing ready to give the processors time to actually attempt connection
* Each processor keeps its own context for nicer processor stopping (child of the global app context)

# How to test?
Run the app, try killing a rabbit connection or deleting a pubsub subscription it uses, it should attempt restart.

# Links
https://trello.com/c/ObrXF2L5/1012-tech-session-restart-pubsub-processors
