### PR TITLE
Send detail to Exception Manager

### DIFF
--- a/models/messageToQuarantine.go
+++ b/models/messageToQuarantine.go
@@ -1,12 +1,13 @@
 package models
 
 type MessageToQuarantine struct {
-	MessageHash    string            `json:"messageHash"`
-	MessagePayload []byte            `json:"messagePayload"`
-	Service        string            `json:"service"`
-	Queue          string            `json:"queue"`
-	ExceptionClass string            `json:"exceptionClass"`
-	RoutingKey     string            `json:"routingKey"`
-	ContentType    string            `json:"contentType"`
-	Headers        map[string]string `json:"headers"`
+	MessageHash      string            `json:"messageHash"`
+	MessagePayload   []byte            `json:"messagePayload"`
+	Service          string            `json:"service"`
+	Queue            string            `json:"queue"`
+	ExceptionClass   string            `json:"exceptionClass"`
+	ExceptionMessage string            `json:"exceptionMessage"`
+	RoutingKey       string            `json:"routingKey"`
+	ContentType      string            `json:"contentType"`
+	Headers          map[string]string `json:"headers"`
 }


### PR DESCRIPTION
# Motivation and Context
PubSub messages are auto-quarantined if they fail unmarshalling or validation, but we were not supplying the underlying error, which could hamper support investigations.

# What has changed
Sent the error text to Exception Manager.

# How to test?
Create errors.

# Links
Trello: https://trello.com/c/bWFM4G4J
