### PR TITLE
RabbitMQ Operator Follow Up

### DIFF
--- a/pubsub-adapter-deployment.yml
+++ b/pubsub-adapter-deployment.yml
@@ -93,7 +93,7 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/gcp-credentials/service-account-key.json"
             - name: RABBIT_HOST
-              value: "rabbitmq"
+              value: "rm-rabbitmq"
             - name: RABBIT_PORT
               value: "5672"
             - name: RABBIT_USERNAME


### PR DESCRIPTION
## Motivation and Context

The kubernetes operator work requires a number of follow-up activities to mitigate unwanted behaviour and improve performance. This includes

- ensuring a robust performance env teardown and setup
- upgrading RabbitMQ versions to the latest 3.8 line
- updating production runbooks to reflect RabbitMQ changes
- pipeline updates to remove helm and corresponding conditionals
- correction of RabbitMQ host in pubsub kubernetes yaml
- removal of excess management UI config as 1.0.0 is based on management image