### PR TITLE
Upgrading and Securing RabbitMQ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,18 @@ version: "3.4"
 services:
   rabbitmq:
     container_name: rabbitmq-pubsub-adapter-dev
-    image: rabbitmq:3.8.2-management
+    image: rabbitmq:3.8-management
     ports:
       - "6369:4369"
       - "46672:25672"
       - "7671-7672:5671-5672"
       - "17671-17672:15671-15672"
       - "17692:15692"
+    environment:
+      - RABBITMQ_CONFIG_FILE=/etc/rabbitmq/rabbitmq.conf
     volumes:
-      - ./rabbitmq/rabbitmq.config:/etc/rabbitmq/rabbitmq.config:ro
-      - ./rabbitmq/definitions.json:/opt/definitions.json:ro
+      - ./rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+      - ./rabbitmq/definitions.json:/opt/definitions.json
 
   pubsub-emulator:
     container_name: pubsub-emulator-pubsub-adapter-dev

--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -1,16 +1,10 @@
 {
-  "rabbit_version": "3.6.10",
   "users": [
     {
       "name": "guest",
       "password_hash": "cTAJdxBZCy5N4cVYPVh0TdRnU1CKTlxiH6mRSee/haEZU33G",
       "hashing_algorithm": "rabbit_password_hashing_sha256",
       "tags": "administrator"
-    }
-  ],
-  "vhosts": [
-    {
-      "name": "/"
     }
   ],
   "permissions": [
@@ -22,9 +16,6 @@
       "read": ".*"
     }
   ],
-  "parameters": [],
-  "global_parameters": [],
-  "policies": [],
   "queues": [
     {
       "name": "goTestReceiptQueue",

--- a/rabbitmq/rabbitmq.conf
+++ b/rabbitmq/rabbitmq.conf
@@ -1,0 +1,3 @@
+management.load_definitions = /opt/definitions.json
+default_user = guest
+loopback_users = none


### PR DESCRIPTION
# Motivation and Context

This change upgrades the RabbitMQ operator, it upgrades the RabbitMQ docker container versions and also delivers a gaggle of hardening and security features for the RabbitMQ cluster.

# What has changed

Changes are applied to the microservices, the tests, the docker development project and the central RabbitMQ provisioning code in the Kubernetes repository.
