### PR TITLE
Watch for SIGTERM os signals to trigger shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 )
 
@@ -28,9 +29,9 @@ func main() {
 	}
 	logger.Logger.Infow("Launching PubSub Adapter")
 
-	// Trap SIGINT to trigger graceful shutdown
+	// Trap SIGINT and SIGTERM to trigger graceful shutdown
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 
 	// Channel for goroutines to notify main of errors
 	errChan := make(chan processor.Error)


### PR DESCRIPTION
# Motivation and Context
K8s sends SIGTERM to kill the pod gracefully, need to watch this signal.

# What has changed
* Watch for SIGTERM to trigger shutdown 

# How to test?
Spin up a branch image in k8s and scale it down, you should see the info logging on graceful shutdown

# Links
https://trello.com/c/qVWmq5PH/2053-fix-os-signal-shutdown-in-pubsub-adapter
